### PR TITLE
Prettyprinting precedence

### DIFF
--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -27,292 +27,292 @@ class Pretty a where
 -- Packages
 
 instance Pretty CompilationUnit where
-  pretty (CompilationUnit mpd ids tds) =
-    vcat $ maybePP mpd: map pretty ids ++ map pretty tds
+  prettyPrec p (CompilationUnit mpd ids tds) =
+    vcat $ ((maybePP p mpd): map (prettyPrec p) ids) ++ map (prettyPrec p) tds
 
 instance Pretty PackageDecl where
-  pretty (PackageDecl name) = text "package" <+> pretty name <> semi
+  prettyPrec p (PackageDecl name) = text "package" <+> prettyPrec p name <> semi
 
 instance Pretty ImportDecl where
-  pretty (ImportDecl st name wc) =
+  prettyPrec p (ImportDecl st name wc) =
     text "import" <+> opt st (text "static")
-                  <+> pretty name <> opt wc (text ".*")
+                  <+> prettyPrec p name <> opt wc (text ".*")
                   <> semi
 
 -----------------------------------------------------------------------
 -- Declarations
 
 instance Pretty TypeDecl where
-  pretty (ClassTypeDecl     cd) = pretty cd
-  pretty (InterfaceTypeDecl id) = pretty id
+  prettyPrec p (ClassTypeDecl     cd) = prettyPrec p cd
+  prettyPrec p (InterfaceTypeDecl id) = prettyPrec p id
 
 instance Pretty ClassDecl where
-  pretty (EnumDecl mods ident impls body) =
-    hsep [hsep (map pretty mods)
+  prettyPrec p (EnumDecl mods ident impls body) =
+    hsep [hsep (map (prettyPrec p) mods)
           , text "enum"
-          , pretty ident 
-          , ppImplements impls
-         ] $$ pretty body
+          , prettyPrec p ident 
+          , ppImplements p impls
+         ] $$ prettyPrec p body
 
-  pretty (ClassDecl mods ident tParams mSuper impls body) =
-    hsep [hsep (map pretty mods)
+  prettyPrec p (ClassDecl mods ident tParams mSuper impls body) =
+    hsep [hsep (map (prettyPrec p) mods)
           , text "class"
-          , pretty ident
-          , ppTypeParams tParams
-          , ppExtends (maybe [] return mSuper)
-          , ppImplements impls
-         ] $$ pretty body
+          , prettyPrec p ident
+          , ppTypeParams p tParams
+          , ppExtends p (maybe [] return mSuper)
+          , ppImplements p impls
+         ] $$ prettyPrec p body
 
 instance Pretty ClassBody where
-  pretty (ClassBody ds) =
-    braceBlock (map pretty ds)
+  prettyPrec p (ClassBody ds) =
+    braceBlock (map (prettyPrec p) ds)
     
 instance Pretty EnumBody where
-  pretty (EnumBody cs ds) =
+  prettyPrec p (EnumBody cs ds) =
     braceBlock $ 
-        punctuate comma (map pretty cs) ++ 
-        opt (not $ null ds) semi : map pretty ds
+        punctuate comma (map (prettyPrec p) cs) ++ 
+        opt (not $ null ds) semi : map (prettyPrec p) ds
 
 instance Pretty EnumConstant where
-  pretty (EnumConstant ident args mBody) =
-    pretty ident 
+  prettyPrec p (EnumConstant ident args mBody) =
+    prettyPrec p ident 
         -- needs special treatment since even the parens are optional
-        <> opt (not $ null args) (ppArgs args) 
-      $$ maybePP mBody
+        <> opt (not $ null args) (ppArgs p args) 
+      $$ maybePP p mBody
 
 instance Pretty InterfaceDecl where
-  pretty (InterfaceDecl mods ident tParams impls body) =
-    hsep [hsep (map pretty mods)
+  prettyPrec p (InterfaceDecl mods ident tParams impls body) =
+    hsep [hsep (map (prettyPrec p) mods)
           , text "interface"
-          , pretty ident
-          , ppTypeParams tParams
-          , ppImplements impls
-         ] $$ pretty body
+          , prettyPrec p ident
+          , ppTypeParams p tParams
+          , ppImplements p impls
+         ] $$ prettyPrec p body
 
 instance Pretty InterfaceBody where
-  pretty (InterfaceBody mds) =
-    braceBlock (map pretty mds)
+  prettyPrec p (InterfaceBody mds) =
+    braceBlock (map (prettyPrec p) mds)
 
 instance Pretty Decl where
-  pretty (MemberDecl md) = pretty md
-  pretty (InitDecl b bl) =
-    opt b (text "static") <+> pretty bl
+  prettyPrec p (MemberDecl md) = prettyPrec p md
+  prettyPrec p (InitDecl b bl) =
+    opt b (text "static") <+> prettyPrec p bl
 
 instance Pretty MemberDecl where
-  pretty (FieldDecl mods t vds) =
-    hsep (map pretty mods ++ pretty t:map pretty vds) <> semi
+  prettyPrec p (FieldDecl mods t vds) =
+    hsep (map (prettyPrec p) mods ++ prettyPrec p t:map (prettyPrec p) vds) <> semi
 
-  pretty (MethodDecl mods tParams mt ident fParams throws body) =
-    hsep [hsep (map pretty mods)
-          , ppTypeParams tParams
-          , ppResultType mt
-          , pretty ident
-          , ppArgs fParams
-          , ppThrows throws
-         ] $$ pretty body
+  prettyPrec p (MethodDecl mods tParams mt ident fParams throws body) =
+    hsep [hsep (map (prettyPrec p) mods)
+          , ppTypeParams p tParams
+          , ppResultType p mt
+          , prettyPrec p ident
+          , ppArgs p fParams
+          , ppThrows p throws
+         ] $$ prettyPrec p body
 
-  pretty (ConstructorDecl mods tParams ident fParams throws body) =
-    hsep [hsep (map pretty mods)
-          , ppTypeParams tParams
-          , pretty ident
-          , ppArgs fParams
-          , ppThrows throws
-         ] $$ pretty body
+  prettyPrec p (ConstructorDecl mods tParams ident fParams throws body) =
+    hsep [hsep (map (prettyPrec p) mods)
+          , ppTypeParams p tParams
+          , prettyPrec p ident
+          , ppArgs p fParams
+          , ppThrows p throws
+         ] $$ prettyPrec p body
 
-  pretty (MemberClassDecl cd) = pretty cd
-  pretty (MemberInterfaceDecl id) = pretty id
+  prettyPrec p (MemberClassDecl cd) = prettyPrec p cd
+  prettyPrec p (MemberInterfaceDecl id) = prettyPrec p id
 
 instance Pretty VarDecl where
-  pretty (VarDecl vdId Nothing) = pretty vdId
-  pretty (VarDecl vdId (Just ie)) =
-	(pretty vdId <+> char '=') <+> pretty ie
+  prettyPrec p (VarDecl vdId Nothing) = prettyPrec p vdId
+  prettyPrec p (VarDecl vdId (Just ie)) =
+	(prettyPrec p vdId <+> char '=') <+> prettyPrec p ie
 
 instance Pretty VarDeclId where
-  pretty (VarId ident) = pretty ident
-  pretty (VarDeclArray vId) = pretty vId
+  prettyPrec p (VarId ident) = prettyPrec p ident
+  prettyPrec p (VarDeclArray vId) = prettyPrec p vId
 
 instance Pretty VarInit where
-  pretty (InitExp e) = pretty e
-  pretty (InitArray (ArrayInit ai)) =
-	text "{" <+> hsep (punctuate comma (map pretty ai)) <+> text "}"
+  prettyPrec p (InitExp e) = prettyPrec p e
+  prettyPrec p (InitArray (ArrayInit ai)) =
+	text "{" <+> hsep (punctuate comma (map (prettyPrec p) ai)) <+> text "}"
 
 instance Pretty FormalParam where
-  pretty (FormalParam mods t b vId) =
-    hsep [hsep (map pretty mods)
-          , pretty t <> opt b (text "...")
-          , pretty vId
+  prettyPrec p (FormalParam mods t b vId) =
+    hsep [hsep (map (prettyPrec p) mods)
+          , prettyPrec p t <> opt b (text "...")
+          , prettyPrec p vId
          ]
 
 instance Pretty MethodBody where
-  pretty (MethodBody mBlock) = maybe semi pretty mBlock
+  prettyPrec p (MethodBody mBlock) = maybe semi (prettyPrec p) mBlock
 
 instance Pretty ConstructorBody where
-  pretty (ConstructorBody mECI stmts) =
-    braceBlock $ maybePP mECI : map pretty stmts
+  prettyPrec p (ConstructorBody mECI stmts) =
+    braceBlock $ maybePP p mECI : map (prettyPrec p) stmts
 
 instance Pretty ExplConstrInv where
-  pretty (ThisInvoke rts args) =
-    ppTypeParams rts <+> text "this" <> ppArgs args <> semi
-  pretty (SuperInvoke rts args) =
-    ppTypeParams rts <+> text "super" <> ppArgs args <> semi
-  pretty (PrimarySuperInvoke e rts args) =
-    pretty e <> char '.' <>
-      ppTypeParams rts <+> text "super" <> ppArgs args <> semi
+  prettyPrec p (ThisInvoke rts args) =
+    ppTypeParams p rts <+> text "this" <> ppArgs p args <> semi
+  prettyPrec p (SuperInvoke rts args) =
+    ppTypeParams p rts <+> text "super" <> ppArgs p args <> semi
+  prettyPrec p (PrimarySuperInvoke e rts args) =
+    prettyPrec p e <> char '.' <>
+      ppTypeParams p rts <+> text "super" <> ppArgs p args <> semi
 
 instance Pretty Modifier where
-  pretty (Annotation ann) = pretty ann $+$ nest (-1) ( text "")
-  pretty mod = text . map toLower $ show mod
+  prettyPrec p (Annotation ann) = prettyPrec p ann $+$ nest (-1) ( text "")
+  prettyPrec p mod = text . map toLower $ show mod
 
 instance Pretty Annotation where
-  pretty x = text "@" <> pretty (annName x) <> case x of
+  prettyPrec p x = text "@" <> prettyPrec p (annName x) <> case x of
          MarkerAnnotation {} -> text ""
-         SingleElementAnnotation {} -> text "(" <> pretty (annValue x) <> text ")"  
-         NormalAnnotation {} -> text "(" <> ppEVList (annKV x) <> text ")"
+         SingleElementAnnotation {} -> text "(" <> prettyPrec p (annValue x) <> text ")"  
+         NormalAnnotation {} -> text "(" <> ppEVList p (annKV x) <> text ")"
 
-ppEVList = hsep . punctuate comma . map (\(k,v) -> pretty k <+> text "=" <+> pretty v)
+ppEVList p = hsep . punctuate comma . map (\(k,v) -> prettyPrec p k <+> text "=" <+> prettyPrec p v)
 
 instance Pretty ElementValue where
-  pretty (EVVal vi) = pretty vi
-  pretty (EVAnn ann) = pretty ann
+  prettyPrec p (EVVal vi) = prettyPrec p vi
+  prettyPrec p (EVAnn ann) = prettyPrec p ann
 
 -----------------------------------------------------------------------
 -- Statements
 
 
 instance Pretty Block where
-  pretty (Block stmts) = braceBlock $ map pretty stmts
+  prettyPrec p (Block stmts) = braceBlock $ map (prettyPrec p) stmts
 
 instance Pretty BlockStmt where
-  pretty (BlockStmt stmt) = pretty stmt
-  pretty (LocalClass cd) = pretty cd
-  pretty (LocalVars mods t vds) =
-    hsep (map pretty mods) <+> pretty t <+> 
-      hsep (punctuate comma $ map pretty vds) <> semi
+  prettyPrec p (BlockStmt stmt) = prettyPrec p stmt
+  prettyPrec p (LocalClass cd) = prettyPrec p cd
+  prettyPrec p (LocalVars mods t vds) =
+    hsep (map (prettyPrec p) mods) <+> prettyPrec p t <+> 
+      hsep (punctuate comma $ map (prettyPrec p) vds) <> semi
 
 instance Pretty Stmt where
-  pretty (StmtBlock block) = pretty block
-  pretty (IfThen c th) =
-    text "if" <+> parens (prettyPrec 0 c) $+$ prettyNestedStmt th
+  prettyPrec p (StmtBlock block) = prettyPrec p block
+  prettyPrec p (IfThen c th) =
+    text "if" <+> parens (prettyPrec 0 c) $+$ prettyNestedStmt 0 th
 
-  pretty (IfThenElse c th el) =
-    text "if" <+> parens (pretty c) $+$ prettyNestedStmt th $+$ text "else" $+$ prettyNestedStmt el
+  prettyPrec p (IfThenElse c th el) =
+    text "if" <+> parens (prettyPrec p c) $+$ prettyNestedStmt 0 th $+$ text "else" $+$ prettyNestedStmt 0 el
       
-  pretty (While c stmt) =
-    text "while" <+> parens (pretty c) $+$ prettyNestedStmt stmt
+  prettyPrec p (While c stmt) =
+    text "while" <+> parens (prettyPrec p c) $+$ prettyNestedStmt 0 stmt
   
-  pretty (BasicFor mInit mE mUp stmt) =
-    text "for" <+> (parens $ hsep [maybePP mInit, semi
-                           , maybePP mE, semi
-                           , maybe empty (hsep . punctuate comma . map pretty) mUp
-                          ]) $+$ prettyNestedStmt stmt
+  prettyPrec p (BasicFor mInit mE mUp stmt) =
+    text "for" <+> (parens $ hsep [maybePP p mInit, semi
+                           , maybePP p mE, semi
+                           , maybe empty (hsep . punctuate comma . map (prettyPrec p)) mUp
+                          ]) $+$ prettyNestedStmt p stmt
 
-  pretty (EnhancedFor mods t ident e stmt) =
+  prettyPrec p (EnhancedFor mods t ident e stmt) =
     hsep [text "for"
           , parens $ hsep [
-                  hsep (map pretty mods)
-                , pretty t
-                , pretty ident
+                  hsep (map (prettyPrec p) mods)
+                , prettyPrec p t
+                , prettyPrec p ident
                 , colon
-                , pretty e
+                , prettyPrec p e
                ]
-          , pretty stmt
+          , prettyPrec p stmt
          ]
 
-  pretty Empty = semi
+  prettyPrec p Empty = semi
   
-  pretty (ExpStmt e) = pretty e <> semi
+  prettyPrec p (ExpStmt e) = prettyPrec p e <> semi
 
-  pretty (Assert ass mE) =
-    text "assert" <+> pretty ass
-      <+> maybe empty ((colon <>) . pretty) mE <> semi
+  prettyPrec p (Assert ass mE) =
+    text "assert" <+> prettyPrec p ass
+      <+> maybe empty ((colon <>) . prettyPrec p) mE <> semi
 
-  pretty (Switch e sBlocks) =
-    text "switch" <+> parens (pretty e) 
-      $$ braceBlock (map pretty sBlocks)
+  prettyPrec p (Switch e sBlocks) =
+    text "switch" <+> parens (prettyPrec p e) 
+      $$ braceBlock (map (prettyPrec p) sBlocks)
 
-  pretty (Do stmt e) =
-    text "do" $+$ pretty stmt <+> text "while" <+> parens (pretty e) <> semi
+  prettyPrec p (Do stmt e) =
+    text "do" $+$ prettyPrec p stmt <+> text "while" <+> parens (prettyPrec p e) <> semi
   
-  pretty (Break mIdent) =
-    text "break" <+> maybePP mIdent <> semi
+  prettyPrec p (Break mIdent) =
+    text "break" <+> maybePP p mIdent <> semi
   
-  pretty (Continue mIdent) =
-    text "continue" <+> maybePP mIdent <> semi
+  prettyPrec p (Continue mIdent) =
+    text "continue" <+> maybePP p mIdent <> semi
   
-  pretty (Return mE) =
-    text "return" <+> maybePP mE <> semi
+  prettyPrec p (Return mE) =
+    text "return" <+> maybePP p mE <> semi
   
-  pretty (Synchronized e block) =
-    text "synchronized" <+> parens (pretty e) $$ pretty block
+  prettyPrec p (Synchronized e block) =
+    text "synchronized" <+> parens (prettyPrec p e) $$ prettyPrec p block
   
-  pretty (Throw e) =
-    text "throw" <+> pretty e <> semi
+  prettyPrec p (Throw e) =
+    text "throw" <+> prettyPrec p e <> semi
   
-  pretty (Try block catches mFinally) =
-    text "try" $$ pretty block $$
-      vcat (map pretty catches ++ [ppFinally mFinally])
+  prettyPrec p (Try block catches mFinally) =
+    text "try" $$ prettyPrec p block $$
+      vcat (map (prettyPrec p) catches ++ [ppFinally mFinally])
    where ppFinally Nothing = empty
-         ppFinally (Just bl) = text "finally" <+> pretty bl
+         ppFinally (Just bl) = text "finally" <+> prettyPrec p bl
 
-  pretty (Labeled ident stmt) =
-    pretty ident <> colon <+> pretty stmt
+  prettyPrec p (Labeled ident stmt) =
+    prettyPrec p ident <> colon <+> prettyPrec p stmt
 
 instance Pretty Catch where
-  pretty (Catch fParam block) =
-    hsep [text "catch", parens (pretty fParam)] $$ pretty block
+  prettyPrec p (Catch fParam block) =
+    hsep [text "catch", parens (prettyPrec p fParam)] $$ prettyPrec p block
 
 instance Pretty SwitchBlock where
-  pretty (SwitchBlock lbl stmts) =
-    vcat (pretty lbl : map (nest 2 . pretty) stmts)
+  prettyPrec p (SwitchBlock lbl stmts) =
+    vcat (prettyPrec p lbl : map (nest 2 . prettyPrec p) stmts)
 
 instance Pretty SwitchLabel where
-  pretty (SwitchCase e) =
-    text "case" <+> pretty e <> colon
-  pretty Default = text "default:"
+  prettyPrec p (SwitchCase e) =
+    text "case" <+> prettyPrec p e <> colon
+  prettyPrec p Default = text "default:"
 
 instance Pretty ForInit where
-  pretty (ForLocalVars mods t vds) =
-    hsep $ map pretty mods ++
-            pretty t: punctuate comma (map pretty vds)
-  pretty (ForInitExps es) =
-    hsep $ punctuate comma (map pretty es)
+  prettyPrec p (ForLocalVars mods t vds) =
+    hsep $ map (prettyPrec p) mods ++
+            prettyPrec p t: punctuate comma (map (prettyPrec p) vds)
+  prettyPrec p (ForInitExps es) =
+    hsep $ punctuate comma (map (prettyPrec p) es)
 
 
 -----------------------------------------------------------------------
 -- Expressions
 
 instance Pretty Exp where
-  prettyPrec _ (Lit l) = pretty l
+  prettyPrec p (Lit l) = prettyPrec p l
   
-  prettyPrec _ (ClassLit mT) =
-    ppResultType mT <> text ".class"
+  prettyPrec p (ClassLit mT) =
+    ppResultType p mT <> text ".class"
 
   prettyPrec _ This = text "this"
   
-  prettyPrec _ (ThisClass name) =
-    pretty name <> text ".this"
+  prettyPrec p (ThisClass name) =
+    prettyPrec p name <> text ".this"
     
-  prettyPrec _ (InstanceCreation tArgs ct args mBody) =
+  prettyPrec p (InstanceCreation tArgs ct args mBody) =
     hsep [text "new" 
-          , ppTypeParams tArgs 
-          , pretty ct <> ppArgs args
-         ] $$ maybePP mBody
+          , ppTypeParams p tArgs 
+          , prettyPrec p ct <> ppArgs p args
+         ] $$ maybePP p mBody
   
-  prettyPrec _ (QualInstanceCreation e tArgs ident args mBody) =
-    hsep [pretty e <> char '.' <> text "new"
-          , ppTypeParams tArgs
-          , pretty ident <> ppArgs args
-         ] $$ maybePP mBody
+  prettyPrec p (QualInstanceCreation e tArgs ident args mBody) =
+    hsep [prettyPrec p e <> char '.' <> text "new"
+          , ppTypeParams p tArgs
+          , prettyPrec p ident <> ppArgs p args
+         ] $$ maybePP p mBody
 
-  prettyPrec _ (ArrayCreate t es k) =
+  prettyPrec p (ArrayCreate t es k) =
     text "new" <+> 
-      hcat (pretty t : map (brackets . pretty) es 
+      hcat (prettyPrec p t : map (brackets . prettyPrec p) es 
                 ++ replicate k (text "[]"))
   
-  prettyPrec _ (ArrayCreateInit t k init) =
+  prettyPrec p (ArrayCreateInit t k init) =
     text "new" 
-      <+> hcat (pretty t : replicate k (text "[]")) 
-      <+> pretty init
+      <+> hcat (prettyPrec p t : replicate k (text "[]")) 
+      <+> prettyPrec p init
 
   prettyPrec p (FieldAccess fa) = parenPrec p 1 $ prettyPrec 1 fa
   
@@ -320,7 +320,7 @@ instance Pretty Exp where
   
   prettyPrec p (ArrayAccess ain) = parenPrec p 1 $ prettyPrec 1 ain
 
-  prettyPrec _ (ExpName name) = pretty name
+  prettyPrec p (ExpName name) = prettyPrec p name
   
   prettyPrec p (PostIncrement e) = parenPrec p 2 $ prettyPrec 2 e <> text "++"
 
@@ -338,11 +338,11 @@ instance Pretty Exp where
 
   prettyPrec p (PreNot e) = parenPrec p 2 $ char '!' <> prettyPrec 2 e
 
-  prettyPrec p (Cast t e) = parenPrec p 2 $ parens (pretty t) <+> prettyPrec 2 e
+  prettyPrec p (Cast t e) = parenPrec p 2 $ parens (prettyPrec p t) <+> prettyPrec 2 e
   
   prettyPrec p (BinOp e1 op e2) =
     let prec = opPrec op in
-    parenPrec p prec (prettyPrec prec e1 <+> pretty op <+> prettyPrec prec e2)
+    parenPrec p prec (prettyPrec prec e1 <+> prettyPrec p op <+> prettyPrec prec e2)
 
   prettyPrec p (InstanceOf e rt) =
     let cp = opPrec LThan in
@@ -351,24 +351,24 @@ instance Pretty Exp where
     
   prettyPrec p (Cond c th el) =
     parenPrec p 13 $ prettyPrec 13 c <+> char '?'
-                   <+> pretty th <+> colon <+> prettyPrec 13 el
+                   <+> prettyPrec p th <+> colon <+> prettyPrec 13 el
 
-  prettyPrec _ (Assign lhs aop e) =
-    hsep [pretty lhs, pretty aop, pretty e]
+  prettyPrec p (Assign lhs aop e) =
+    hsep [prettyPrec p lhs, prettyPrec p aop, prettyPrec p e]
 
 
 instance Pretty Literal where
-  pretty (Int i) = text (show i)
-  pretty (Word i) = text (show i) <> char 'L'
-  pretty (Float f) = text (show f) <> char 'F'
-  pretty (Double d) = text (show d)
-  pretty (Boolean b) = text . map toLower $ show b
-  pretty (Char c) = text (show c)
-  pretty (String s) = text (show s)
-  pretty (Null) = text "null"
+  prettyPrec p (Int i) = text (show i)
+  prettyPrec p (Word i) = text (show i) <> char 'L'
+  prettyPrec p (Float f) = text (show f) <> char 'F'
+  prettyPrec p (Double d) = text (show d)
+  prettyPrec p (Boolean b) = text . map toLower $ show b
+  prettyPrec p (Char c) = text (show c)
+  prettyPrec p (String s) = text (show s)
+  prettyPrec p (Null) = text "null"
 
 instance Pretty Op where
-  pretty op = text $ case op of
+  prettyPrec p op = text $ case op of
     Mult    -> "*"
     Div     -> "/"
     Rem     -> "%"
@@ -390,7 +390,7 @@ instance Pretty Op where
     COr     -> "||"
     
 instance Pretty AssignOp where
-  pretty aop = text $ case aop of
+  prettyPrec p aop = text $ case aop of
     EqualA  -> "="
     MultA   -> "*="
     DivA    -> "/="
@@ -405,135 +405,135 @@ instance Pretty AssignOp where
     OrA     -> "|="
 
 instance Pretty Lhs where
-  pretty (NameLhs name) = pretty name
-  pretty (FieldLhs fa) = pretty fa
-  pretty (ArrayLhs ain) = pretty ain
+  prettyPrec p (NameLhs name) = prettyPrec p name
+  prettyPrec p (FieldLhs fa) = prettyPrec p fa
+  prettyPrec p (ArrayLhs ain) = prettyPrec p ain
 
 instance Pretty ArrayIndex where
-  pretty (ArrayIndex ref e) = pretty ref <> brackets (pretty e)
+  prettyPrec p (ArrayIndex ref e) = prettyPrec p ref <> brackets (prettyPrec p e)
 
 instance Pretty FieldAccess where
-  pretty (PrimaryFieldAccess e ident) =
-    pretty e <> char '.' <> pretty ident
-  pretty (SuperFieldAccess ident) =
-    text "super." <> pretty ident
-  pretty (ClassFieldAccess name ident) =
-    pretty name <> text ".super." <> pretty ident
+  prettyPrec p (PrimaryFieldAccess e ident) =
+    prettyPrec p e <> char '.' <> prettyPrec p ident
+  prettyPrec p (SuperFieldAccess ident) =
+    text "super." <> prettyPrec p ident
+  prettyPrec p (ClassFieldAccess name ident) =
+    prettyPrec p name <> text ".super." <> prettyPrec p ident
 
 instance Pretty MethodInvocation where
-  pretty (MethodCall name args) =
-    pretty name <> ppArgs args
+  prettyPrec p (MethodCall name args) =
+    prettyPrec p name <> ppArgs p args
 
-  pretty (PrimaryMethodCall e tArgs ident args) =
-    hcat [pretty e, char '.', ppTypeParams tArgs, 
-           pretty ident, ppArgs args]
+  prettyPrec p (PrimaryMethodCall e tArgs ident args) =
+    hcat [prettyPrec p e, char '.', ppTypeParams p tArgs, 
+           prettyPrec p ident, ppArgs p args]
 
-  pretty (SuperMethodCall tArgs ident args) =
-    hcat [text "super.", ppTypeParams tArgs,
-           pretty ident, ppArgs args]
+  prettyPrec p (SuperMethodCall tArgs ident args) =
+    hcat [text "super.", ppTypeParams p tArgs,
+           prettyPrec p ident, ppArgs p args]
 
-  pretty (ClassMethodCall name tArgs ident args) =
-    hcat [pretty name, text ".super.", ppTypeParams tArgs,
-           pretty ident, ppArgs args]
+  prettyPrec p (ClassMethodCall name tArgs ident args) =
+    hcat [prettyPrec p name, text ".super.", ppTypeParams p tArgs,
+           prettyPrec p ident, ppArgs p args]
   
-  pretty (TypeMethodCall name tArgs ident args) =
-    hcat [pretty name, char '.', ppTypeParams tArgs,
-           pretty ident, ppArgs args]
+  prettyPrec p (TypeMethodCall name tArgs ident args) =
+    hcat [prettyPrec p name, char '.', ppTypeParams p tArgs,
+           prettyPrec p ident, ppArgs p args]
 
 instance Pretty ArrayInit where
-  pretty (ArrayInit vInits) =
-    braceBlock $ map (\v -> pretty v <> comma) vInits
-    --braces $ hsep (punctuate comma (map pretty vInits))
+  prettyPrec p (ArrayInit vInits) =
+    braceBlock $ map (\v -> prettyPrec p v <> comma) vInits
+    --braces $ hsep (punctuate comma (map (prettyPrec p) vInits))
 
 
-ppArgs :: Pretty a => [a] -> Doc
-ppArgs = parens . hsep . punctuate comma . map pretty
+ppArgs :: Pretty a => Int -> [a] -> Doc
+ppArgs p = parens . hsep . punctuate comma . map (prettyPrec p)
 
 -----------------------------------------------------------------------
 -- Types
 
 instance Pretty Type where
-  pretty (PrimType pt) = pretty pt
-  pretty (RefType  rt) = pretty rt
+  prettyPrec p (PrimType pt) = prettyPrec p pt
+  prettyPrec p (RefType  rt) = prettyPrec p rt
 
 instance Pretty RefType where
-  pretty (ClassRefType ct) = pretty ct
-  pretty (ArrayType t) = pretty t <> text "[]"
+  prettyPrec p (ClassRefType ct) = prettyPrec p ct
+  prettyPrec p (ArrayType t) = prettyPrec p t <> text "[]"
 
 instance Pretty ClassType where
-  pretty (ClassType itas) =
+  prettyPrec p (ClassType itas) =
     hcat . punctuate (char '.') $
-      map (\(i,tas) -> pretty i <> ppTypeParams tas) itas
+      map (\(i,tas) -> prettyPrec p i <> ppTypeParams p tas) itas
 
 instance Pretty TypeArgument where
-  pretty (ActualType rt) = pretty rt
-  pretty (Wildcard mBound) = char '?' <+> maybePP mBound
+  prettyPrec p (ActualType rt) = prettyPrec p rt
+  prettyPrec p (Wildcard mBound) = char '?' <+> maybePP p mBound
 
 instance Pretty WildcardBound where
-  pretty (ExtendsBound rt) = text "extends" <+> pretty rt
-  pretty (SuperBound   rt) = text "super"   <+> pretty rt
+  prettyPrec p (ExtendsBound rt) = text "extends" <+> prettyPrec p rt
+  prettyPrec p (SuperBound   rt) = text "super"   <+> prettyPrec p rt
 
 instance Pretty PrimType where
-  pretty BooleanT = text "boolean"
-  pretty ByteT    = text "byte"
-  pretty ShortT   = text "short"
-  pretty IntT     = text "int"
-  pretty LongT    = text "long"
-  pretty CharT    = text "char"
-  pretty FloatT   = text "float"
-  pretty DoubleT  = text "double"
+  prettyPrec p BooleanT = text "boolean"
+  prettyPrec p ByteT    = text "byte"
+  prettyPrec p ShortT   = text "short"
+  prettyPrec p IntT     = text "int"
+  prettyPrec p LongT    = text "long"
+  prettyPrec p CharT    = text "char"
+  prettyPrec p FloatT   = text "float"
+  prettyPrec p DoubleT  = text "double"
 
 instance Pretty TypeParam where
-  pretty (TypeParam ident rts) =
-    pretty ident 
+  prettyPrec p (TypeParam ident rts) =
+    prettyPrec p ident 
       <+> opt (not $ null rts) 
            (hsep $ text "extends": 
-                    punctuate (text " &") (map pretty rts))
+                    punctuate (text " &") (map (prettyPrec p) rts))
 
-ppTypeParams :: Pretty a => [a] -> Doc
-ppTypeParams [] = empty
-ppTypeParams tps = char '<' 
-    <> hsep (punctuate comma (map pretty tps))
+ppTypeParams :: Pretty a => Int -> [a] -> Doc
+ppTypeParams _ [] = empty
+ppTypeParams p tps = char '<' 
+    <> hsep (punctuate comma (map (prettyPrec p) tps))
     <> char '>'
 
-ppImplements :: [RefType] -> Doc
-ppImplements [] = empty
-ppImplements rts = text "implements" 
-    <+> hsep (punctuate comma (map pretty rts))
+ppImplements :: Int -> [RefType] -> Doc
+ppImplements _ [] = empty
+ppImplements p rts = text "implements" 
+    <+> hsep (punctuate comma (map (prettyPrec p) rts))
 
-ppExtends :: [RefType] -> Doc
-ppExtends [] = empty
-ppExtends rts = text "extends" 
-    <+> hsep (punctuate comma (map pretty rts))
+ppExtends :: Int -> [RefType] -> Doc
+ppExtends _ [] = empty
+ppExtends p rts = text "extends" 
+    <+> hsep (punctuate comma (map (prettyPrec p) rts))
 
-ppThrows :: [ExceptionType] -> Doc
-ppThrows [] = empty
-ppThrows ets = text "throws" 
-    <+> hsep (punctuate comma (map pretty ets))
+ppThrows :: Int -> [ExceptionType] -> Doc
+ppThrows _ [] = empty
+ppThrows p ets = text "throws" 
+    <+> hsep (punctuate comma (map (prettyPrec p) ets))
 
-ppResultType :: Maybe Type -> Doc
-ppResultType Nothing = text "void"
-ppResultType (Just a) = pretty a
+ppResultType :: Int -> Maybe Type -> Doc
+ppResultType _ Nothing = text "void"
+ppResultType p (Just a) = prettyPrec p a
 
 -----------------------------------------------------------------------
 -- Names and identifiers
 
 instance Pretty Name where
-  pretty (Name is) =
-    hcat (punctuate (char '.') $ map pretty is)
+  prettyPrec p (Name is) =
+    hcat (punctuate (char '.') $ map (prettyPrec p) is)
 
 instance Pretty Ident where
-  pretty (Ident s) = text s
+  prettyPrec p (Ident s) = text s
 
 
 -----------------------------------------------------------------------
 -- Help functionality
-prettyNestedStmt :: Stmt -> Doc
-prettyNestedStmt p@(StmtBlock b) = pretty p
-prettyNestedStmt p = nest 2 (pretty p)
+prettyNestedStmt :: Int -> Stmt -> Doc
+prettyNestedStmt prio p@(StmtBlock b) = prettyPrec prio p
+prettyNestedStmt prio p = nest 2 (prettyPrec prio p)
 
-maybePP :: Pretty a => Maybe a -> Doc
-maybePP = maybe empty pretty
+maybePP :: Pretty a => Int -> Maybe a -> Doc
+maybePP p = maybe empty (prettyPrec p)
 
 opt :: Bool -> Doc -> Doc
 opt x a = if x then a else empty


### PR DESCRIPTION
Hi,

first of all thanks for your great work!

I think, I discovered an error concerning the operator precedence of cast:

``` haskell
import Language.Java.Syntax
import Language.Java.Pretty

castError = 
 MethodInv $ PrimaryMethodCall 
             (Cast (RefType . ClassRefType $ ClassType [(Ident "SomeObject", [])])
                   (ExpName $ Name [Ident "someVar"]))
             []
             (Ident "someMethod")
             []

prettyError = pretty castError
```

The code above produces

``` java
(SomeObject) someVar.someMethod()
```

but should produce

``` java
((SomeObject) someVar).someMethod()
```

The bug is hidden in the code for method invocations:

``` haskell
prettyPrec p (MethodInv mi) = parenPrec p 1 $ prettyPrec 1 mi
```

will call `pretty` from `MethodInvocation`, because `MethodInvocation` does not define `prettyPrec`.

My pull request contains a version which uses `prettyPrec p` everywhere. This way precedences always get passed down. It might be improved in a later version to use a state monad hiding the argument in places where it is not necessary.

It would be cool to have the repaired version in hackage. 

Thanks for considering my request,
 Jan

~~Edit: The latest commit additionally fixes a copy and paste typo in the documentation of `ClassMethodCall`~~
