### PR TITLE
fix fieldDecl printer for multiple variables with same type part

### DIFF
--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -100,7 +100,7 @@ instance Pretty Decl where
 
 instance Pretty MemberDecl where
   prettyPrec p (FieldDecl mods t vds) =
-    hsep (map (prettyPrec p) mods ++ prettyPrec p t:map (prettyPrec p) vds) <> semi
+    hsep (map (prettyPrec p) mods ++ prettyPrec p t:punctuate (text ",") (map (prettyPrec p) vds)) <> semi
 
   prettyPrec p (MethodDecl mods tParams mt ident fParams throws body) =
     hsep [hsep (map (prettyPrec p) mods)


### PR DESCRIPTION
Parsing and then printing this code:

```
public class Cls {
  int x, y, z;
}
```

was printing this:

```
public class Cls
{
  int x y z;
}
```

This patches fixes this.

The case with single variable still works:

```
public class Cls
{
  int x;
}
```
