### PR TITLE
Fix for test miscMath3.

### DIFF
--- a/tests/java/good/TemplateMethods.java
+++ b/tests/java/good/TemplateMethods.java
@@ -1,0 +1,10 @@
+
+class Some {
+   <T> void some() {}
+   public final <T> void somePub() {}
+   public static <T> void someStatic() {}
+}
+
+class SomeOther extends Some {
+   <T> void some() { super.<T>some(); }
+}

--- a/tests/java/good/miscMath3.java
+++ b/tests/java/good/miscMath3.java
@@ -1,4 +1,4 @@
 import java.util.Random;
 class MiscMath<T extends Number>{
-	void <S> loop(S s){ this.<S>loop(s);}
+   <S> void loop(S s){ this.<S>loop(s);}
 }


### PR DESCRIPTION
The problem with this test is that

void <S> loop(S s){ this.<S>loop(s);}

is not correct template method definition.

<S> void loop(S s){ this.<S>loop(s);}

is correct definition, at it parses ok.

Added additional test for the template methods.
