### PR TITLE
Added support for diamond operator.

### DIFF
--- a/Language/Java/Parser.hs
+++ b/Language/Java/Parser.hs
@@ -1068,7 +1068,7 @@ bounds :: P [RefType]
 bounds = tok KW_Extends >> seplist1 refType (tok Op_And)
 
 typeArgs :: P [TypeArgument]
-typeArgs = angles $ seplist1 typeArg comma
+typeArgs = angles $ seplist typeArg comma
 
 typeArg :: P TypeArgument
 typeArg = tok Op_Query >> Wildcard <$> opt wildcardBound

--- a/tests/java/good/diamond-operator.java
+++ b/tests/java/good/diamond-operator.java
@@ -1,0 +1,7 @@
+
+
+class WithDiamond {
+   public void method() {
+      final List<Type> list = new ArrayList<>();
+   }
+}


### PR DESCRIPTION
In latest javas there is 'diamond operator' which means
derive type of generic from context.

To make it supported, limitation for at least one argument
in instance creation type args was removed.