### PR TITLE
Removed ".super." from ClassFieldAccess

### DIFF
--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -419,7 +419,7 @@ instance Pretty FieldAccess where
   prettyPrec p (SuperFieldAccess ident) =
     text "super." <> prettyPrec p ident
   prettyPrec p (ClassFieldAccess name ident) =
-    prettyPrec p name <> text ".super." <> prettyPrec p ident
+    prettyPrec p name <> prettyPrec p ident
 
 instance Pretty MethodInvocation where
   prettyPrec p (MethodCall name args) =

--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -419,7 +419,7 @@ instance Pretty FieldAccess where
   prettyPrec p (SuperFieldAccess ident) =
     text "super." <> prettyPrec p ident
   prettyPrec p (ClassFieldAccess name ident) =
-    prettyPrec p name <> prettyPrec p ident
+    prettyPrec p name <> text "." <> prettyPrec p ident
 
 instance Pretty MethodInvocation where
   prettyPrec p (MethodCall name args) =


### PR DESCRIPTION
According to the haddock documentation `ClassFieldAccesss` should access  "a (static) field of a named class" and not the super class.