### PR TITLE
Add generic instance

### DIFF
--- a/Language/Java/Syntax.hs
+++ b/Language/Java/Syntax.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE CPP, DeriveDataTypeable #-}
+{-# LANGUAGE CPP, DeriveDataTypeable, DeriveGeneric #-}
 module Language.Java.Syntax where
 
 import Data.Data
+import GHC.Generics (Generic)
 
-#define DERIVE deriving (Eq,Ord,Show,Typeable,Data)
+#define DERIVE deriving (Eq,Ord,Show,Typeable,Generic,Data)
 
 -----------------------------------------------------------------------
 -- Packages


### PR DESCRIPTION
I have a project based on your library. The thing is, somewhere I need to derive generic instance for one of the datatypes, which uses `Syntax.Op` for Java operators, but `Syntax.Op` has no instance of Generic. So I was wondering would you consider adding generic instance to all your datatypes? I know the change is just for my personal convenience, I could maintain my own fork of the library instead.

Thanks!