### PR TITLE
Small improvement to MethodRef handling

### DIFF
--- a/Language/Java/Parser.hs
+++ b/Language/Java/Parser.hs
@@ -769,7 +769,7 @@ lambdaExp = Lambda
 
 methodRef :: P Exp
 methodRef = MethodRef 
-            <$> (ident <*  (tok MethodRefSep))
+            <$> (name <*  (tok MethodRefSep))
             <*> ident
 
 {-

--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -356,7 +356,9 @@ instance Pretty Exp where
 
   prettyPrec p (Assign lhs aop e) =
     hsep [prettyPrec p lhs, prettyPrec p aop, prettyPrec p e]
-
+  
+  prettyPrec p (MethodRef i1 i2) =
+    prettyPrec p i1 <+> text "::" <+> prettyPrec p i2
 
 instance Pretty Literal where
   prettyPrec p (Int i) = text (show i)

--- a/Language/Java/Syntax.hs
+++ b/Language/Java/Syntax.hs
@@ -346,7 +346,7 @@ data Exp
     -- | Lambda expression
     | Lambda LambdaParams LambdaExpression
     -- | Method reference
-    | MethodRef Ident Ident
+    | MethodRef Name Ident
   DERIVE
 
 -- | A literal denotes a fixed, unchanging value.


### PR DESCRIPTION
Added pretty printing for MethodRef.
Also changed the first argument to the MethodRef type constructor to name.

Testcase:

```
package test;

import java.util.function.Consumer;

class Test {
    public static void main(String[] args) {
        String baz = "test";
        foo(System.out::println, baz);
    }

    private static void foo(Consumer<String> c, String s) {
        c.accept(s);
    }
}
```

parses to

```
Right (CompilationUnit (Just (PackageDecl (Name [Ident "test"]))) [ImportDecl False (Name [Ident "java",Ident "util",Ident "function",Ident "Consumer"]) False] [ClassTypeDecl (ClassDecl [] (Ident "Test") [] Nothing [] (ClassBody [MemberDecl (MethodDecl [Public,Static] [] Nothing (Ident "main") [FormalParam [] (RefType (ArrayType (RefType (ClassRefType (ClassType [(Ident "String",[])]))))) False (VarId (Ident "args"))] [] (MethodBody (Just (Block [LocalVars [] (RefType (ClassRefType (ClassType [(Ident "String",[])]))) [VarDecl (VarId (Ident "baz")) (Just (InitExp (Lit (String "test"))))],BlockStmt (ExpStmt (MethodInv (MethodCall (Name [Ident "foo"]) [MethodRef (Name [Ident "System",Ident "out"]) (Ident "println"),ExpName (Name [Ident "baz"])])))])))),MemberDecl (MethodDecl [Private,Static] [] Nothing (Ident "foo") [FormalParam [] (RefType (ClassRefType (ClassType [(Ident "Consumer",[ActualType (ClassRefType (ClassType [(Ident "String",[])]))])]))) False (VarId (Ident "c")),FormalParam [] (RefType (ClassRefType (ClassType [(Ident "String",[])]))) False (VarId (Ident "s"))] [] (MethodBody (Just (Block [BlockStmt (ExpStmt (MethodInv (MethodCall (Name [Ident "c",Ident "accept"]) [ExpName (Name [Ident "s"])])))]))))]))])
```

and pretty prints to

```
Right package test;
import java.util.function.Consumer;
class Test
{
  public static void main (String[] args)
  {
    String baz = "test";
    foo(System.out :: println, baz);
  }
  private static void foo (Consumer<String> c, String s)
  {
    c.accept(s);
  }
}
```