### PR TITLE
Improved Diamond operator (parsing and printing)

### DIFF
--- a/Language/Java/Parser.hs
+++ b/Language/Java/Parser.hs
@@ -732,10 +732,25 @@ instanceCreationNPS :: P Exp
 instanceCreationNPS =
     do tok KW_New
        tas <- lopt typeArgs
-       ct  <- classType
+       ct <- seplist ident period
+       mtaod <- opt typeArgumentsOrDiamond
        as  <- args
        mcb <- opt classBody
-       return $ InstanceCreation tas ct as mcb
+       return $ InstanceCreation tas ct mtaod as mcb
+
+typeArgumentsOrDiamond :: P TypeArgumentsOrDiamond
+typeArgumentsOrDiamond =
+  do
+    tok Op_LThan
+    ret <-  (do
+              tok Op_GThan
+              return Diamond)
+            <|>
+            (do
+              ta <- seplist typeArg comma
+              tok Op_GThan
+              return $ TypeArguments ta)
+    return ret
 
 instanceCreationSuffix :: P (Exp -> Exp)
 instanceCreationSuffix =

--- a/Language/Java/Parser.hs
+++ b/Language/Java/Parser.hs
@@ -733,35 +733,27 @@ instanceCreationNPS =
     do tok KW_New
        tas <- lopt typeArgs
        tds <- typeDeclSpecifier
-       mtaod <- opt typeArgumentsOrDiamond
        as  <- args
        mcb <- opt classBody
-       return $ InstanceCreation tas tds mtaod as mcb
+       return $ InstanceCreation tas tds as mcb
 
 typeDeclSpecifier :: P TypeDeclSpecifier
 typeDeclSpecifier =
-    (do ct <- classType
-        period
-        i <- ident
-        return $ QualifiedTypeDeclSpecifier ct i
+    (try $ do ct <- classType
+              period
+              i <- ident
+              tok Op_LThan
+              tok Op_GThan
+              return $ TypeDeclSpecifierWithDiamond ct i Diamond
     ) <|>
-    (do i <- ident
-        return $ TypeDeclSpecifier i
+    (try $ do i <- ident
+              tok Op_LThan
+              tok Op_GThan
+              return $ TypeDeclSpecifierUnqualifiedWithDiamond i Diamond
+    ) <|>
+    (do ct <- classType
+        return $ TypeDeclSpecifier ct
     )
-
-typeArgumentsOrDiamond :: P TypeArgumentsOrDiamond
-typeArgumentsOrDiamond =
-  do
-    tok Op_LThan
-    ret <-  (do
-              tok Op_GThan
-              return Diamond)
-            <|>
-            (do
-              ta <- seplist typeArg comma
-              tok Op_GThan
-              return $ TypeArguments ta)
-    return ret
 
 instanceCreationSuffix :: P (Exp -> Exp)
 instanceCreationSuffix =

--- a/Language/Java/Parser.hs
+++ b/Language/Java/Parser.hs
@@ -732,11 +732,22 @@ instanceCreationNPS :: P Exp
 instanceCreationNPS =
     do tok KW_New
        tas <- lopt typeArgs
-       ct <- seplist ident period
+       tds <- typeDeclSpecifier
        mtaod <- opt typeArgumentsOrDiamond
        as  <- args
        mcb <- opt classBody
-       return $ InstanceCreation tas ct mtaod as mcb
+       return $ InstanceCreation tas tds mtaod as mcb
+
+typeDeclSpecifier :: P TypeDeclSpecifier
+typeDeclSpecifier =
+    (do ct <- classType
+        period
+        i <- ident
+        return $ QualifiedTypeDeclSpecifier ct i
+    ) <|>
+    (do i <- ident
+        return $ TypeDeclSpecifier i
+    )
 
 typeArgumentsOrDiamond :: P TypeArgumentsOrDiamond
 typeArgumentsOrDiamond =
@@ -1104,7 +1115,7 @@ bounds :: P [RefType]
 bounds = tok KW_Extends >> seplist1 refType (tok Op_And)
 
 typeArgs :: P [TypeArgument]
-typeArgs = angles $ seplist typeArg comma
+typeArgs = angles $ seplist1 typeArg comma
 
 typeArg :: P TypeArgument
 typeArg = tok Op_Query >> Wildcard <$> opt wildcardBound

--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -293,10 +293,10 @@ instance Pretty Exp where
   prettyPrec p (ThisClass name) =
     prettyPrec p name <> text ".this"
     
-  prettyPrec p (InstanceCreation tArgs tds mtaod args mBody) =
+  prettyPrec p (InstanceCreation tArgs tds args mBody) =
     hsep [text "new" 
           , ppTypeParams p tArgs 
-          , prettyPrec p tds <> maybePP p mtaod <> ppArgs p args
+          , prettyPrec p tds <> ppArgs p args
          ] $$ maybePP p mBody
   
   prettyPrec p (QualInstanceCreation e tArgs ident args mBody) =
@@ -485,14 +485,11 @@ instance Pretty TypeArgument where
   prettyPrec p (Wildcard mBound) = char '?' <+> maybePP p mBound
 
 instance Pretty TypeDeclSpecifier where
-  prettyPrec p (TypeDeclSpecifier i) = prettyPrec p i
-  prettyPrec p (QualifiedTypeDeclSpecifier qls i) =  prettyPrec p qls <> char '.' <> prettyPrec p i
+  prettyPrec p (TypeDeclSpecifier ct) = prettyPrec p ct
+  prettyPrec p (TypeDeclSpecifierWithDiamond ct i d) =  prettyPrec p ct <> char '.' <> prettyPrec p i <> prettyPrec p d
+  prettyPrec p (TypeDeclSpecifierUnqualifiedWithDiamond i d) = prettyPrec p i <> prettyPrec p d
 
-instance Pretty TypeArgumentsOrDiamond where
-  prettyPrec p (TypeArguments tps) =
-    char '<' 
-    <> hsep (punctuate comma (map (prettyPrec p) tps))
-    <> char '>'
+instance Pretty Diamond where
   prettyPrec p Diamond = text "<>"
 
 instance Pretty WildcardBound where

--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -293,10 +293,10 @@ instance Pretty Exp where
   prettyPrec p (ThisClass name) =
     prettyPrec p name <> text ".this"
     
-  prettyPrec p (InstanceCreation tArgs ct args mBody) =
+  prettyPrec p (InstanceCreation tArgs ct mtaod args mBody) =
     hsep [text "new" 
           , ppTypeParams p tArgs 
-          , prettyPrec p ct <> ppArgs p args
+          , ((hcat . punctuate (char '.')) (map (prettyPrec p) ct)) <> maybePP p mtaod <> ppArgs p args
          ] $$ maybePP p mBody
   
   prettyPrec p (QualInstanceCreation e tArgs ident args mBody) =
@@ -483,6 +483,13 @@ instance Pretty ClassType where
 instance Pretty TypeArgument where
   prettyPrec p (ActualType rt) = prettyPrec p rt
   prettyPrec p (Wildcard mBound) = char '?' <+> maybePP p mBound
+
+instance Pretty TypeArgumentsOrDiamond where
+  prettyPrec p (TypeArguments tps) =
+    char '<' 
+    <> hsep (punctuate comma (map (prettyPrec p) tps))
+    <> char '>'
+  prettyPrec p Diamond = text "<>"
 
 instance Pretty WildcardBound where
   prettyPrec p (ExtendsBound rt) = text "extends" <+> prettyPrec p rt

--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -293,10 +293,10 @@ instance Pretty Exp where
   prettyPrec p (ThisClass name) =
     prettyPrec p name <> text ".this"
     
-  prettyPrec p (InstanceCreation tArgs ct mtaod args mBody) =
+  prettyPrec p (InstanceCreation tArgs tds mtaod args mBody) =
     hsep [text "new" 
           , ppTypeParams p tArgs 
-          , ((hcat . punctuate (char '.')) (map (prettyPrec p) ct)) <> maybePP p mtaod <> ppArgs p args
+          , prettyPrec p tds <> maybePP p mtaod <> ppArgs p args
          ] $$ maybePP p mBody
   
   prettyPrec p (QualInstanceCreation e tArgs ident args mBody) =
@@ -483,6 +483,10 @@ instance Pretty ClassType where
 instance Pretty TypeArgument where
   prettyPrec p (ActualType rt) = prettyPrec p rt
   prettyPrec p (Wildcard mBound) = char '?' <+> maybePP p mBound
+
+instance Pretty TypeDeclSpecifier where
+  prettyPrec p (TypeDeclSpecifier i) = prettyPrec p i
+  prettyPrec p (QualifiedTypeDeclSpecifier qls i) =  prettyPrec p qls <> char '.' <> prettyPrec p i
 
 instance Pretty TypeArgumentsOrDiamond where
   prettyPrec p (TypeArguments tps) =

--- a/Language/Java/Syntax.hs
+++ b/Language/Java/Syntax.hs
@@ -337,7 +337,7 @@ data Exp
     -- | The first argument is a list of non-wildcard type arguments to a generic constructor.
     --   What follows is the type to be instantiated, the list of arguments passed to the constructor, and
     --   optionally a class body that makes the constructor result in an object of an /anonymous/ class.
-    | InstanceCreation [TypeArgument] ClassType [Argument] (Maybe ClassBody)
+    | InstanceCreation [TypeArgument] [Ident] (Maybe TypeArgumentsOrDiamond) [Argument] (Maybe ClassBody)
     -- | A qualified class instance creation expression enables the creation of instances of inner member classes
     --   and their anonymous subclasses.
     | QualInstanceCreation Exp [TypeArgument] Ident [Argument] (Maybe ClassBody)

--- a/Language/Java/Syntax.hs
+++ b/Language/Java/Syntax.hs
@@ -337,7 +337,7 @@ data Exp
     -- | The first argument is a list of non-wildcard type arguments to a generic constructor.
     --   What follows is the type to be instantiated, the list of arguments passed to the constructor, and
     --   optionally a class body that makes the constructor result in an object of an /anonymous/ class.
-    | InstanceCreation [TypeArgument] [Ident] (Maybe TypeArgumentsOrDiamond) [Argument] (Maybe ClassBody)
+    | InstanceCreation [TypeArgument] TypeDeclSpecifier (Maybe TypeArgumentsOrDiamond) [Argument] (Maybe ClassBody)
     -- | A qualified class instance creation expression enables the creation of instances of inner member classes
     --   and their anonymous subclasses.
     | QualInstanceCreation Exp [TypeArgument] Ident [Argument] (Maybe ClassBody)

--- a/Language/Java/Syntax.hs
+++ b/Language/Java/Syntax.hs
@@ -337,7 +337,7 @@ data Exp
     -- | The first argument is a list of non-wildcard type arguments to a generic constructor.
     --   What follows is the type to be instantiated, the list of arguments passed to the constructor, and
     --   optionally a class body that makes the constructor result in an object of an /anonymous/ class.
-    | InstanceCreation [TypeArgument] TypeDeclSpecifier (Maybe TypeArgumentsOrDiamond) [Argument] (Maybe ClassBody)
+    | InstanceCreation [TypeArgument] TypeDeclSpecifier [Argument] (Maybe ClassBody)
     -- | A qualified class instance creation expression enables the creation of instances of inner member classes
     --   and their anonymous subclasses.
     | QualInstanceCreation Exp [TypeArgument] Ident [Argument] (Maybe ClassBody)

--- a/Language/Java/Syntax/Types.hs
+++ b/Language/Java/Syntax/Types.hs
@@ -32,6 +32,11 @@ data TypeArgument
     | ActualType RefType
   deriving (Eq,Show,Typeable,Generic,Data)
 
+data TypeDeclSpecifier
+    = TypeDeclSpecifier Ident
+    | QualifiedTypeDeclSpecifier ClassType Ident
+  deriving (Eq,Show,Typeable,Generic,Data)
+
 data TypeArgumentsOrDiamond
     = TypeArguments [TypeArgument]
     | Diamond

--- a/Language/Java/Syntax/Types.hs
+++ b/Language/Java/Syntax/Types.hs
@@ -32,6 +32,11 @@ data TypeArgument
     | ActualType RefType
   deriving (Eq,Show,Typeable,Generic,Data)
 
+data TypeArgumentsOrDiamond
+    = TypeArguments [TypeArgument]
+    | Diamond
+  deriving (Eq,Show,Typeable,Generic,Data)
+
 -- | Wildcards may be given explicit bounds, either upper (@extends@) or lower (@super@) bounds.
 data WildcardBound
     = ExtendsBound RefType

--- a/Language/Java/Syntax/Types.hs
+++ b/Language/Java/Syntax/Types.hs
@@ -33,13 +33,12 @@ data TypeArgument
   deriving (Eq,Show,Typeable,Generic,Data)
 
 data TypeDeclSpecifier
-    = TypeDeclSpecifier Ident
-    | QualifiedTypeDeclSpecifier ClassType Ident
+    = TypeDeclSpecifier ClassType
+    | TypeDeclSpecifierWithDiamond ClassType Ident Diamond
+    | TypeDeclSpecifierUnqualifiedWithDiamond Ident Diamond
   deriving (Eq,Show,Typeable,Generic,Data)
 
-data TypeArgumentsOrDiamond
-    = TypeArguments [TypeArgument]
-    | Diamond
+data Diamond = Diamond
   deriving (Eq,Show,Typeable,Generic,Data)
 
 -- | Wildcards may be given explicit bounds, either upper (@extends@) or lower (@super@) bounds.


### PR DESCRIPTION
The previous implementation was able to parse the diamond operator, but did not include it in the AST.

Take for example:

```java
class WithDiamond {
   public void method() {
      final List<Type> list = new Bar<Test>.Foo<Test>.ArrayList<>();
   }
}
```

Previously, this could be parsed, but the AST was (surrounding AST parts omitted for brevity)

```haskell
InstanceCreation [] (ClassType [
(Ident "Bar",[ActualType (ClassRefType (ClassType [(Ident "Test",[])]))]),
(Ident "Foo",[ActualType (ClassRefType (ClassType [(Ident "Test",[])]))]),
(Ident "ArrayList",[])]) [] Nothing
```

which is the same as for `new Bar<Test>.Foo<Test>.ArrayList()`.

This lead to the following output for our example
```java
class WithDiamond
{
  public void method ()
  {
    final List<Type> list = new Bar<Test>.Foo<Test>.ArrayList();
  }
}
```
omitting the diamond operator and thus creating a warning.

In order to fix this, this solution, a new type `TypeDeclSpecifier ` is introduced, which can parse the following cases:
`ClassType` (as before)
`Ident Diamond` (an unqualified type declaration specifier followed by a diamond, e.g. `ArrayList<>`
`ClassType Ident Diamond` (a qualified type declaration specifier followed by a diamond, e.g. `Test<Foo>.ArrayList<>`

With this solution, the AST part corresponding to the previous one reads:

```haskell
InstanceCreation [] (TypeDeclSpecifierWithDiamond (ClassType [
(Ident "Bar",[ActualType (ClassRefType (ClassType [(Ident "Test",[])]))]),
(Ident "Foo",[ActualType (ClassRefType (ClassType [(Ident "Test",[])]))])])
(Ident "ArrayList") Diamond) [] Nothing
```

Although slightly more verbose, this includes the Diamond in the AST while keeping the definition of ClassType intact and thus the changes localized.

Language.Java.Pretty was extended to print the newly introduced types, so now the output for the example is as expected:
```java
class WithDiamond
{
  public void method ()
  {
    final List<Type> list = new Bar<Test>.Foo<Test>.ArrayList<>();
  }
}
```