### PR TITLE
Interfaces should use extends instead of implements

### DIFF
--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -87,7 +87,7 @@ instance Pretty InterfaceDecl where
           , text "interface"
           , prettyPrec p ident
           , ppTypeParams p tParams
-          , ppImplements p impls
+          , ppExtends p impls
          ] $$ prettyPrec p body
 
 instance Pretty InterfaceBody where

--- a/tests/java/good/Gauge.java
+++ b/tests/java/good/Gauge.java
@@ -1,0 +1,26 @@
+// From the codahale metrics library: https://github.com/codahale/metrics
+package com.codahale.metrics;
+
+
+/**
+ * A gauge metric is an instantaneous reading of a particular value. To instrument a queue's depth,
+ * for example:<br>
+ * <pre><code>
+ * final Queue&lt;String&gt; queue = new ConcurrentLinkedQueue&lt;String&gt;();
+ * final Gauge&lt;Integer&gt; queueDepth = new Gauge&lt;Integer&gt;() {
+ *     public Integer getValue() {
+ *         return queue.size();
+ *     }
+ * };
+ * </code></pre>
+ *
+ * @param <T> the type of the metric's value
+ */
+public interface Gauge<T> extends Metric {
+	/**
+	 * Returns the metric's current value.
+	 *
+	 * @return the metric's current value
+	 */
+	T getValue();
+}


### PR DESCRIPTION
```ecu <- parser compilationUnit <$> readFile "./tests/java/good/Gauge.java"```
Note: Gauge **extends** Metric

The compilation unit:

```fmap show ecu```

```Right "CompilationUnit (Just (PackageDecl (Name [Ident \"com\",Ident \"codahale\",Ident \"metrics\"]))) [] [InterfaceTypeDecl (InterfaceDecl InterfaceNormal Public [TypeParam (Ident \"T\") []] ClassRefType (ClassType [(Ident \"Metric\",[])]))]"```

Pretty print the compilation unit:

```fmap pretty ecu```

```
Right package com.codahale.metrics;
public interface Gauge implements Metric
{
T getValue ()
;
}
```

Issue: **implements** Metric (instead of extends)