### PR TITLE
Synchronised should use American English spelling

### DIFF
--- a/Language/Java/Parser.hs
+++ b/Language/Java/Parser.hs
@@ -338,7 +338,7 @@ modifier =
     <|> tok KW_Native      >> return Native
     <|> tok KW_Transient   >> return Transient
     <|> tok KW_Volatile    >> return Volatile
-    <|> tok KW_Synchronized >> return Synchronized
+    <|> tok KW_Synchronized >> return Synchronized_
     <|> Annotation <$> annotation
 
 annotation :: P Annotation

--- a/Language/Java/Parser.hs
+++ b/Language/Java/Parser.hs
@@ -338,7 +338,7 @@ modifier =
     <|> tok KW_Native      >> return Native
     <|> tok KW_Transient   >> return Transient
     <|> tok KW_Volatile    >> return Volatile
-    <|> tok KW_Synchronized >> return Synchronised
+    <|> tok KW_Synchronized >> return Synchronized
     <|> Annotation <$> annotation
 
 annotation :: P Annotation

--- a/Language/Java/Syntax.hs
+++ b/Language/Java/Syntax.hs
@@ -201,8 +201,22 @@ data Modifier
     | Volatile
     | Native
     | Annotation Annotation
-    | Synchronized
-  deriving (Eq,Show,Typeable,Generic,Data)
+    | Synchronized_
+  deriving (Eq,Typeable,Generic,Data)
+
+instance Show Modifier where
+   show Public = "public" 
+   show Private = "private"
+   show Protected = "protected"
+   show Abstract = "abstract"
+   show Final = "final"
+   show Static = "static"
+   show StrictFP = "strictfp"
+   show Transient = "transient"
+   show Volatile = "volatile"
+   show Native = "native"
+   show (Annotation a) = show a
+   show Synchronized_ = "synchronized"
 
 -- | Annotations have three different forms: no-parameter, single-parameter or key-value pairs
 data Annotation = NormalAnnotation        { annName :: Name -- Not type because not type generics not allowed

--- a/Language/Java/Syntax.hs
+++ b/Language/Java/Syntax.hs
@@ -201,7 +201,7 @@ data Modifier
     | Volatile
     | Native
     | Annotation Annotation
-    | Synchronised
+    | Synchronized
   deriving (Eq,Show,Typeable,Generic,Data)
 
 -- | Annotations have three different forms: no-parameter, single-parameter or key-value pairs


### PR DESCRIPTION
Not sure if I fixed it the right way...

However here is the issue I am facing:

Original code

```public synchronized int size() {```

Code after parsing and pretty printing

```public synchronised int size() {```

synchronised should be written in the US spelling