### PR TITLE
Fixed #8: Distinguish between infix operation and combination of infix operation

### DIFF
--- a/Language/Java/Parser.hs
+++ b/Language/Java/Parser.hs
@@ -663,6 +663,10 @@ infixExp = do
 
 infixExpSuffix :: P (Exp -> Exp)
 infixExpSuffix =
+    (do
+      op <- infixCombineOp
+      ie2 <- infixExp
+      return $ \ie1 -> BinOp ie1 op ie2) <|>
     (do op <- infixOp
         e2 <- unaryExp
         return $ \e1 -> BinOp e1 op e2) <|>
@@ -1012,6 +1016,15 @@ assignOp =
     (tok Op_CaretE   >> return XorA     ) <|>
     (tok Op_OrE      >> return OrA      )
 
+infixCombineOp :: P Op
+infixCombineOp = 
+    (tok Op_And     >> return And       ) <|>
+    (tok Op_Caret   >> return Xor       ) <|>
+    (tok Op_Or      >> return Or        ) <|>
+    (tok Op_AAnd    >> return CAnd      ) <|>
+    (tok Op_OOr     >> return COr       )
+
+
 infixOp :: P Op
 infixOp =
     (tok Op_Star    >> return Mult      ) <|>
@@ -1036,12 +1049,7 @@ infixOp =
     (tok Op_LThanE  >> return LThanE    ) <|>
     (tok Op_GThanE  >> return GThanE    ) <|>
     (tok Op_Equals  >> return Equal     ) <|>
-    (tok Op_BangE   >> return NotEq     ) <|>
-    (tok Op_And     >> return And       ) <|>
-    (tok Op_Caret   >> return Xor       ) <|>
-    (tok Op_Or      >> return Or        ) <|>
-    (tok Op_AAnd    >> return CAnd      ) <|>
-    (tok Op_OOr     >> return COr       )
+    (tok Op_BangE   >> return NotEq     )
 
 
 ----------------------------------------------------------------------------


### PR DESCRIPTION
An example

```parser Language.Java.Parser.exp <$> ["y == null && x == null"]
[Right (BinOp (BinOp (BinOp (ExpName (Name [Ident "y"])) Equal (Lit Null)) CAnd (ExpName (Name [Ident "x"]))) Equal (Lit Null))]```

Instead of ```((y == null) && (x == null))``` it parsed as ```(((y == null) && x) == null)```