### PR TITLE
print square brackets for array init

### DIFF
--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -131,7 +131,7 @@ instance Pretty VarDecl where
 
 instance Pretty VarDeclId where
   prettyPrec p (VarId ident) = prettyPrec p ident
-  prettyPrec p (VarDeclArray vId) = prettyPrec p vId
+  prettyPrec p (VarDeclArray vId) = prettyPrec p vId <> text "[]"
 
 instance Pretty VarInit where
   prettyPrec p (InitExp e) = prettyPrec p e

--- a/tests/java/good/TestArray.java
+++ b/tests/java/good/TestArray.java
@@ -1,0 +1,13 @@
+public class TestArray {
+    public static void main(String[] args) {
+        while (true) { int x = 1; }
+        if (1 + 1 == 2) {
+        } else {
+            int y = 2, z = 4;
+            while (y > 0) y--;
+            System.out.println(y);
+            int w[][] = {{1,2}, {3}};
+        }
+        
+    }
+}


### PR DESCRIPTION
```int w[][] = {{1,2}, {3}};```

Is transformed (after parse and pretty) into

```int w```