### PR TITLE
Put brackets around assign statement inside if, if needed

### DIFF
--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -356,7 +356,7 @@ instance Pretty Exp where
                    <+> prettyPrec p th <+> colon <+> prettyPrec 13 el
 
   prettyPrec p (Assign lhs aop e) =
-    hsep [prettyPrec p lhs, prettyPrec p aop, prettyPrec p e]
+    parenPrec p 13 $ hsep [prettyPrec p lhs, prettyPrec p aop, prettyPrec p e]
 
   prettyPrec p (Lambda params body) =
     prettyPrec p params <+> text "->" <+> prettyPrec p body


### PR DESCRIPTION
```
> pretty <$> parser stmt "if ((as = cells) != null) {}"
Right if (as = cells != null)
{
}
```

Assignment inside if should have bracket around it
