### PR TITLE
Allow right part of BinOp to be an infixExp

### DIFF
--- a/Language/Java/Parser.hs
+++ b/Language/Java/Parser.hs
@@ -683,14 +683,15 @@ infixExpSuffix =
       ie2 <- infixExp
       return $ \ie1 -> BinOp ie1 op ie2) <|>
     (do op <- infixOp
-        e2 <- unaryExp
+        e2 <- infixExp
         return $ \e1 -> BinOp e1 op e2) <|>
     (do tok KW_Instanceof
         t  <- refType
         return $ \e1 -> InstanceOf e1 t)
 
 unaryExp :: P Exp
-unaryExp = try preIncDec <|>
+unaryExp = 
+    try preIncDec <|>
     try (do
         op <- prefixOp
         ue <- unaryExp


### PR DESCRIPTION
Related to the discussion in https://github.com/vincenthz/language-java/pull/52

```
> parser Language.Java.Parser.exp "i < 10*y"
```

Is parsed as 
```
Right (BinOp (BinOp (ExpName (Name [Ident "i"])) LThan (Lit (Int 10))) Mult (ExpName (Name [Ident "y"])))
```

I think it should instead be:

```
(BinOp (ExpName (Name [Ident "i"])) LThan (BinOp (Lit (Int 10)) Mult (ExpName (Name [Ident "y"]))))
```