### PR TITLE
Split up between compare operators and other infix operators

### DIFF
--- a/Language/Java/Parser.hs
+++ b/Language/Java/Parser.hs
@@ -1086,10 +1086,6 @@ infixOp =
        tok Op_GThan
        return RShift    ) <|>
            
-    (tok Op_GThan   >> return GThan     ) <|>                                          
-    (tok Op_LThanE  >> return LThanE    ) <|>
-    (tok Op_GThanE  >> return GThanE    ) <|>
-    (tok Op_Equals  >> return Equal     ) <|>
     (tok Op_BangE   >> return NotEq     )
 
 


### PR DESCRIPTION
Split up between compare operators and other infix operators

```
> parser Language.Java.Parser.exp "i < 10*y" 
```

Becomes

```
(BinOp (BinOp (ExpName (Name [Ident "i"])) LThan (Lit (Int 10))) Mult (ExpName (Name [Ident "y"])))
```

It should instead be

```
(BinOp (ExpName (Name [Ident "i"])) LThan (BinOp (Lit (Int 10)) Mult (ExpName (Name [Ident "y"]))))
```
