### PR TITLE
Fix the build on GHC 8.4

### DIFF
--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Language.Java.Pretty where
 
 import Text.PrettyPrint
@@ -7,6 +8,9 @@ import Data.List (intersperse)
 
 import Language.Java.Syntax
 
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
 
 prettyPrint :: Pretty a => a -> String
 prettyPrint = show . pretty


### PR DESCRIPTION
`base-4.11` (bundled with GHC 8.4.1) re-exported `(Data.Semigroup.<>)`, which clashes with the `(<>)` operator from `pretty`.