### PR TITLE
Exposing the `P` alias for documentation

### DIFF
--- a/Language/Java/Lexer.x
+++ b/Language/Java/Lexer.x
@@ -1,7 +1,7 @@
 {
 {-# LANGUAGE BangPatterns #-}
 {-# OPTIONS_GHC -fno-warn-tabs -fno-warn-unused-binds #-}
-module Language.Java.Lexer (L(..), Token(..), lexer) where
+module Language.Java.Lexer (L(..), Token(..), Pos, lexer) where
 
 import Numeric
 import Data.Char

--- a/Language/Java/Parser.hs
+++ b/Language/Java/Parser.hs
@@ -30,7 +30,9 @@ module Language.Java.Parser (
 
     empty, list, list1, seplist, seplist1, opt, bopt, lopt,
 
-    comma, semiColon, period, colon
+    comma, semiColon, period, colon,
+
+    P
 
     ) where
 

--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -366,7 +366,7 @@ instance Pretty Exp where
     prettyPrec p params <+> text "->" <+> prettyPrec p body
 
   prettyPrec p (MethodRef i1 i2) =
-    prettyPrec p i1 <+> text "::" <+> prettyPrec p i2
+    prettyPrec p i1 <+> text "::" <+> maybe (text "new") (prettyPrec p) i2
 
 instance Pretty LambdaParams where
   prettyPrec p (LambdaSingleParam ident) = prettyPrec p ident
@@ -539,9 +539,10 @@ ppThrows _ [] = empty
 ppThrows p ets = text "throws"
     <+> hsep (punctuate comma (map (prettyPrec p) ets))
 
-ppDefault :: Int -> Maybe Exp -> Doc
-ppDefault _ Nothing = empty
-ppDefault p (Just exp) = text "default" <+> prettyPrec p exp
+ppDefault :: Int -> DefaultValue -> Doc
+ppDefault _ None = empty
+ppDefault p (Single exp) = text "default" <+> prettyPrec p exp
+ppDefault p (Array exps) = text "default" <+> braceBlock (map (prettyPrec p) exps)
 
 ppResultType :: Int -> Maybe Type -> Doc
 ppResultType _ Nothing = text "void"

--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP, TypeSynonymInstances, FlexibleInstances #-}
 module Language.Java.Pretty where
 
 import Text.PrettyPrint
@@ -24,7 +24,7 @@ parenPrec inheritedPrec currentPrec t
 class Pretty a where
   pretty :: a -> Doc
   pretty = prettyPrec 0
-  
+
   prettyPrec :: Int -> a -> Doc
   prettyPrec _ = pretty
 
@@ -55,7 +55,7 @@ instance Pretty ClassDecl where
   prettyPrec p (EnumDecl mods ident impls body) =
     hsep [hsep (map (prettyPrec p) mods)
           , text "enum"
-          , prettyPrec p ident 
+          , prettyPrec p ident
           , ppImplements p impls
          ] $$ prettyPrec p body
 
@@ -71,18 +71,18 @@ instance Pretty ClassDecl where
 instance Pretty ClassBody where
   prettyPrec p (ClassBody ds) =
     braceBlock (map (prettyPrec p) ds)
-    
+
 instance Pretty EnumBody where
   prettyPrec p (EnumBody cs ds) =
-    braceBlock $ 
-        punctuate comma (map (prettyPrec p) cs) ++ 
+    braceBlock $
+        punctuate comma (map (prettyPrec p) cs) ++
         opt (not $ null ds) semi : map (prettyPrec p) ds
 
 instance Pretty EnumConstant where
   prettyPrec p (EnumConstant ident args mBody) =
-    prettyPrec p ident 
+    prettyPrec p ident
         -- needs special treatment since even the parens are optional
-        <> opt (not $ null args) (ppArgs p args) 
+        <> opt (not $ null args) (ppArgs p args)
       $$ maybePP p mBody
 
 instance Pretty InterfaceDecl where
@@ -172,7 +172,7 @@ instance Pretty Modifier where
 instance Pretty Annotation where
   prettyPrec p x = text "@" <> prettyPrec p (annName x) <> case x of
          MarkerAnnotation {} -> text ""
-         SingleElementAnnotation {} -> text "(" <> prettyPrec p (annValue x) <> text ")"  
+         SingleElementAnnotation {} -> text "(" <> prettyPrec p (annValue x) <> text ")"
          NormalAnnotation {} -> text "(" <> ppEVList p (annKV x) <> text ")"
 
 ppEVList p = hsep . punctuate comma . map (\(k,v) -> prettyPrec p k <+> text "=" <+> prettyPrec p v)
@@ -192,7 +192,7 @@ instance Pretty BlockStmt where
   prettyPrec p (BlockStmt stmt) = prettyPrec p stmt
   prettyPrec p (LocalClass cd) = prettyPrec p cd
   prettyPrec p (LocalVars mods t vds) =
-    hsep (map (prettyPrec p) mods) <+> prettyPrec p t <+> 
+    hsep (map (prettyPrec p) mods) <+> prettyPrec p t <+>
       hsep (punctuate comma $ map (prettyPrec p) vds) <> semi
 
 instance Pretty Stmt where
@@ -202,10 +202,10 @@ instance Pretty Stmt where
 
   prettyPrec p (IfThenElse c th el) =
     text "if" <+> parens (prettyPrec p c) $+$ prettyNestedStmt 0 th $+$ text "else" $+$ prettyNestedStmt 0 el
-      
+
   prettyPrec p (While c stmt) =
     text "while" <+> parens (prettyPrec p c) $+$ prettyNestedStmt 0 stmt
-  
+
   prettyPrec p (BasicFor mInit mE mUp stmt) =
     text "for" <+> (parens $ hsep [maybePP p mInit, semi
                            , maybePP p mE, semi
@@ -225,7 +225,7 @@ instance Pretty Stmt where
          ]
 
   prettyPrec p Empty = semi
-  
+
   prettyPrec p (ExpStmt e) = prettyPrec p e <> semi
 
   prettyPrec p (Assert ass mE) =
@@ -233,27 +233,27 @@ instance Pretty Stmt where
       <+> maybe empty ((colon <>) . prettyPrec p) mE <> semi
 
   prettyPrec p (Switch e sBlocks) =
-    text "switch" <+> parens (prettyPrec p e) 
+    text "switch" <+> parens (prettyPrec p e)
       $$ braceBlock (map (prettyPrec p) sBlocks)
 
   prettyPrec p (Do stmt e) =
     text "do" $+$ prettyPrec p stmt <+> text "while" <+> parens (prettyPrec p e) <> semi
-  
+
   prettyPrec p (Break mIdent) =
     text "break" <+> maybePP p mIdent <> semi
-  
+
   prettyPrec p (Continue mIdent) =
     text "continue" <+> maybePP p mIdent <> semi
-  
+
   prettyPrec p (Return mE) =
     text "return" <+> maybePP p mE <> semi
-  
+
   prettyPrec p (Synchronized e block) =
     text "synchronized" <+> parens (prettyPrec p e) $$ prettyPrec p block
-  
+
   prettyPrec p (Throw e) =
     text "throw" <+> prettyPrec p e <> semi
-  
+
   prettyPrec p (Try block catches mFinally) =
     text "try" $$ prettyPrec p block $$
       vcat (map (prettyPrec p) catches ++ [ppFinally mFinally])
@@ -289,21 +289,21 @@ instance Pretty ForInit where
 
 instance Pretty Exp where
   prettyPrec p (Lit l) = prettyPrec p l
-  
+
   prettyPrec p (ClassLit mT) =
     ppResultType p mT <> text ".class"
 
   prettyPrec _ This = text "this"
-  
+
   prettyPrec p (ThisClass name) =
     prettyPrec p name <> text ".this"
-    
+
   prettyPrec p (InstanceCreation tArgs tds args mBody) =
-    hsep [text "new" 
-          , ppTypeParams p tArgs 
+    hsep [text "new"
+          , ppTypeParams p tArgs
           , prettyPrec p tds <> ppArgs p args
          ] $$ maybePP p mBody
-  
+
   prettyPrec p (QualInstanceCreation e tArgs ident args mBody) =
     hsep [prettyPrec p e <> char '.' <> text "new"
           , ppTypeParams p tArgs
@@ -311,41 +311,41 @@ instance Pretty Exp where
          ] $$ maybePP p mBody
 
   prettyPrec p (ArrayCreate t es k) =
-    text "new" <+> 
-      hcat (prettyPrec p t : map (brackets . prettyPrec p) es 
+    text "new" <+>
+      hcat (prettyPrec p t : map (brackets . prettyPrec p) es
                 ++ replicate k (text "[]"))
-  
+
   prettyPrec p (ArrayCreateInit t k init) =
-    text "new" 
-      <+> hcat (prettyPrec p t : replicate k (text "[]")) 
+    text "new"
+      <+> hcat (prettyPrec p t : replicate k (text "[]"))
       <+> prettyPrec p init
 
   prettyPrec p (FieldAccess fa) = parenPrec p 1 $ prettyPrec 1 fa
-  
+
   prettyPrec p (MethodInv mi) = parenPrec p 1 $ prettyPrec 1 mi
-  
+
   prettyPrec p (ArrayAccess ain) = parenPrec p 1 $ prettyPrec 1 ain
 
   prettyPrec p (ExpName name) = prettyPrec p name
-  
+
   prettyPrec p (PostIncrement e) = parenPrec p 1 $ prettyPrec 2 e <> text "++"
 
   prettyPrec p (PostDecrement e) = parenPrec p 1 $ prettyPrec 2 e <> text "--"
 
   prettyPrec p (PreIncrement e)  = parenPrec p 1 $ text "++" <> prettyPrec 2 e
-  
+
   prettyPrec p (PreDecrement e)  = parenPrec p 1 $ text "--" <> prettyPrec 2 e
 
   prettyPrec p (PrePlus e) = parenPrec p 2 $ char '+' <> prettyPrec 2 e
-  
+
   prettyPrec p (PreMinus e) = parenPrec p 2 $ char '-' <> prettyPrec 2 e
-  
-  prettyPrec p (PreBitCompl e) = parenPrec p 2 $ char '~' <> prettyPrec 2 e 
+
+  prettyPrec p (PreBitCompl e) = parenPrec p 2 $ char '~' <> prettyPrec 2 e
 
   prettyPrec p (PreNot e) = parenPrec p 2 $ char '!' <> prettyPrec 2 e
 
   prettyPrec p (Cast t e) = parenPrec p 2 $ parens (prettyPrec p t) <+> prettyPrec 2 e
-  
+
   prettyPrec p (BinOp e1 op e2) =
     let prec = opPrec op in
     parenPrec p prec (prettyPrec prec e1 <+> prettyPrec p op <+> prettyPrec prec e2)
@@ -354,7 +354,7 @@ instance Pretty Exp where
     let cp = opPrec LThan in
     parenPrec p cp $ prettyPrec cp e
                    <+> text "instanceof" <+> prettyPrec cp rt
-    
+
   prettyPrec p (Cond c th el) =
     parenPrec p 13 $ prettyPrec 13 c <+> char '?'
                    <+> prettyPrec p th <+> colon <+> prettyPrec 13 el
@@ -408,7 +408,7 @@ instance Pretty Op where
     Or      -> "|"
     CAnd    -> "&&"
     COr     -> "||"
-    
+
 instance Pretty AssignOp where
   prettyPrec p aop = text $ case aop of
     EqualA  -> "="
@@ -445,7 +445,7 @@ instance Pretty MethodInvocation where
     prettyPrec p name <> ppArgs p args
 
   prettyPrec p (PrimaryMethodCall e tArgs ident args) =
-    hcat [prettyPrec p e, char '.', ppTypeParams p tArgs, 
+    hcat [prettyPrec p e, char '.', ppTypeParams p tArgs,
            prettyPrec p ident, ppArgs p args]
 
   prettyPrec p (SuperMethodCall tArgs ident args) =
@@ -455,7 +455,7 @@ instance Pretty MethodInvocation where
   prettyPrec p (ClassMethodCall name tArgs ident args) =
     hcat [prettyPrec p name, text ".super.", ppTypeParams p tArgs,
            prettyPrec p ident, ppArgs p args]
-  
+
   prettyPrec p (TypeMethodCall name tArgs ident args) =
     hcat [prettyPrec p name, char '.', ppTypeParams p tArgs,
            prettyPrec p ident, ppArgs p args]
@@ -513,30 +513,30 @@ instance Pretty PrimType where
 
 instance Pretty TypeParam where
   prettyPrec p (TypeParam ident rts) =
-    prettyPrec p ident 
-      <+> opt (not $ null rts) 
-           (hsep $ text "extends": 
+    prettyPrec p ident
+      <+> opt (not $ null rts)
+           (hsep $ text "extends":
                     punctuate (text " &") (map (prettyPrec p) rts))
 
 ppTypeParams :: Pretty a => Int -> [a] -> Doc
 ppTypeParams _ [] = empty
-ppTypeParams p tps = char '<' 
+ppTypeParams p tps = char '<'
     <> hsep (punctuate comma (map (prettyPrec p) tps))
     <> char '>'
 
 ppImplements :: Int -> [RefType] -> Doc
 ppImplements _ [] = empty
-ppImplements p rts = text "implements" 
+ppImplements p rts = text "implements"
     <+> hsep (punctuate comma (map (prettyPrec p) rts))
 
 ppExtends :: Int -> [RefType] -> Doc
 ppExtends _ [] = empty
-ppExtends p rts = text "extends" 
+ppExtends p rts = text "extends"
     <+> hsep (punctuate comma (map (prettyPrec p) rts))
 
 ppThrows :: Int -> [ExceptionType] -> Doc
 ppThrows _ [] = empty
-ppThrows p ets = text "throws" 
+ppThrows p ets = text "throws"
     <+> hsep (punctuate comma (map (prettyPrec p) ets))
 
 ppDefault :: Int -> Maybe Exp -> Doc

--- a/Language/Java/Syntax.hs
+++ b/Language/Java/Syntax.hs
@@ -13,6 +13,7 @@ module Language.Java.Syntax
     , InterfaceKind(..)
     , DeclA(..)
     , MemberDeclA(..)
+    , DefaultValueA(..)
     , VarDeclA(..)
     , VarDeclId(..)
     , VarInitA(..)
@@ -70,6 +71,10 @@ module Language.Java.Syntax
     , pattern ConstructorDecl
     , pattern MemberClassDecl
     , pattern MemberInterfaceDecl
+    , DefaultValue
+    , pattern None
+    , pattern Single
+    , pattern Array
     , VarDecl
     , pattern VarDecl
     , VarInit
@@ -269,13 +274,19 @@ data MemberDeclA a
     -- | The variables of a class type are introduced by field declarations.
     = FieldDeclA [ModifierA a] Type [VarDeclA a] a
     -- | A method declares executable code that can be invoked, passing a fixed number of values as arguments.
-    | MethodDeclA      [ModifierA a] [TypeParam] (Maybe Type) Ident [FormalParamA a] [ExceptionType] (Maybe ( ExpA a)) ( MethodBodyA a) a
+    | MethodDeclA      [ModifierA a] [TypeParam] (Maybe Type) Ident [FormalParamA a] [ExceptionType] (DefaultValueA a) ( MethodBodyA a) a
     -- | A constructor is used in the creation of an object that is an instance of a class.
     | ConstructorDeclA [ModifierA a] [TypeParam]              Ident [FormalParamA a] [ExceptionType] ( ConstructorBodyA a) a
     -- | A member class is a class whose declaration is directly enclosed in another class or interface declaration.
     | MemberClassDeclA ( ClassDeclA a) a
     -- | A member interface is an interface whose declaration is directly enclosed in another class or interface declaration.
     | MemberInterfaceDeclA ( InterfaceDeclA a) a
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+
+data DefaultValueA a
+    = NoneA
+    | SingleA (ExpA a)
+    | ArrayA [ExpA a]
   deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | A declaration of a variable, which may be explicitly initialized.
@@ -551,7 +562,7 @@ data ExpA a
     -- | Lambda expression
     | LambdaA (LambdaParamsA a) ( LambdaExpressionA a) a
     -- | Method reference
-    | MethodRefA Name Ident a
+    | MethodRefA Name (Maybe Ident ) a
   deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | The left-hand side of an assignment expression. This operand may be a named variable, such as a local
@@ -645,3 +656,4 @@ unfunctor ''LhsA
 unfunctor ''ArrayIndexA
 unfunctor ''FieldAccessA
 unfunctor ''LambdaParamsA
+unfunctor ''DefaultValueA

--- a/Language/Java/Syntax/Util.hs
+++ b/Language/Java/Syntax/Util.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE LambdaCase, TupleSections #-}
+module Language.Java.Syntax.Util where
+
+import Language.Haskell.TH
+import Data.Maybe
+import Control.Monad
+
+-- | @replaceTypeWhere needle replacement haystack@ replaces every occurrence of
+-- @needle@ in @haystack@ with @replacement@
+--
+-- Caveats:
+--    * Does not investigate some of the newer constructors of 'Type', such
+--      as 'AppKindT' and 'ImplicitParamT'.
+--    * If @needle@ is a type variable this does not correctly handle 'ForallT' (it
+--      will variables bound by the forall)
+replaceTypeWhere :: Type -> Type -> Type -> Type
+replaceTypeWhere target replacement = go
+  where
+    go = \case
+        a | a == target -> replacement
+        ForallT b c t -> ForallT b c (go t)
+        AppT a b -> AppT (go a) (go b)
+        SigT t k -> SigT (go t) k
+        InfixT t1 n t2 -> InfixT (go t1) n (go t2)
+        UInfixT t1 n t2 -> UInfixT (go t1) n (go t2)
+        ParensT t -> ParensT (go t)
+        other -> other
+
+-- | Given a type declaration such as
+-- @
+--   data MyTypeF a b
+--       = Con1F T1 b a
+--       | Con2F T2
+-- @
+-- This creates the following definitions
+-- @
+--   type MyType b = MyType b ()
+--   pattern Con1 b :: -> b -> MyType
+--   pattern Con1 a b = Con1F a b ()
+--   pattern Con2 :: T2 -> MyType
+--   pattern Con2 a = Con2F b
+-- @
+-- i.e. it
+-- 1. creates a type alias that is the original type name with the last character
+--    removed and the last type parameter instantiated as @()@
+-- 2. for each constructor it creates a pattern (and signature) which omits all
+--    fields of the same type as the last, stripped type parameter removed and
+--    on the rhs filled with @()@
+unfunctor :: Name -> Q [Dec]
+unfunctor =
+  reify >=> \case
+    TyConI dec -> do
+      fpats <- concatMap snd <$> filterM (fmap isNothing . lookupValueName . fst) pats
+      return $
+          TySynD unfunctorName (reverse rest) (functorType `AppT` unitT) : fpats
+      where pats =
+                map rewriteConstr constrs
+            functorType = applyVars functorName
+            unfunctorName = rename functorName
+            unfunctorType = applyVars unfunctorName
+            applyVars name =
+              foldl AppT (ConT name) $ map (VarT . unVarBndr) $ reverse rest
+            unitT = ConT $ tupleTypeName 0
+            unVarBndr (PlainTV a) = a
+            unVarBndr (KindedTV a _) = a
+            rename = mkName . renameStr
+            renameStr name' = newName'
+              where
+                base = nameBase name'
+                newName' = take (length base - 1) base
+            functorVar:rest = reverse bndrs
+            functorVarT = VarT $ unVarBndr functorVar
+            rewriteConstr con@(NormalC conName fields) = (patternNameStr,)
+              [ PatSynSigD
+                  patternName
+                  (foldr (\x y -> ArrowT `AppT` x `AppT` y) unfunctorType newTypes)
+              , PatSynD
+                  patternName
+                  (PrefixPatSyn newVars)
+                  ImplBidir
+                  (ConP
+                     conName
+                     (map (maybe (ConP (tupleDataName 0) []) (VarP . snd)) newFields))
+              ]
+              where
+                (newTypes, newVars) = unzip $ catMaybes newFields
+                patternNameStr = renameStr conName
+                patternName = mkName patternNameStr
+                newFields :: [Maybe (Type, Name)]
+                newFields =
+                  reverse $
+                  fst $ foldl f ([], map (mkName . pure) ['a' .. 'z']) fields
+                f (vars, reservoir@(newVar:restVars)) (_, ty')
+                  | ty' == functorVarT =
+                    (Nothing : vars, reservoir)
+                  | otherwise =
+                    (Just (rewriteType ty', newVar) : vars, restVars)
+                f _ _ =
+                  error $
+                  "Too many type variables needed for constructor " ++ show con
+            rewriteConstr con =
+              error $ "Cannot handle constructor type " ++ show con
+            rewriteType = replaceTypeWhere functorVarT unitT
+            (functorName, bndrs, constrs) =
+              case dec of
+                DataD _ctx name' bndrs' _kind constrs' _derives ->
+                  (name', bndrs', constrs')
+                NewtypeD _ctx name' bndrs' _kind constr' _derives ->
+                  (name', bndrs', [constr'])
+                _ -> error $ "Unrecognized declaration type " ++ show dec
+    info -> fail $ "Unrecognized entity " ++ show info

--- a/language-java.cabal
+++ b/language-java.cabal
@@ -27,6 +27,7 @@ Library
                       , array >= 0.1
                       , pretty >= 1.0
                       , parsec >= 3.0
+                      , template-haskell
 
   if impl(ghc < 7.6)
     Build-Depends:      syb
@@ -37,9 +38,10 @@ Library
                         Language.Java.Syntax,
                         Language.Java.Parser,
                         Language.Java.Pretty
-  
+
   Other-modules:	    Language.Java.Syntax.Types
-                        Language.Java.Syntax.Exp
+                      Language.Java.Syntax.Exp
+                      Language.Java.Syntax.Util
 
 Test-Suite test-java-parse
   type:              exitcode-stdio-1.0

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ScopedTypeVariables, FlexibleInstances, TypeSynonymInstances #-}
 module Main where
 
 import Test.Tasty
@@ -57,7 +57,7 @@ getAllJavaPaths path = map (path </>) . filter isJavaFile <$> getDirectoryConten
 main = do
     exists <- doesDirectoryExist testJavaDirectory
     when (not exists) $ error "cannot find tests files java directory"
-    
+
     allGoodJavas <- getAllJavaPaths (testJavaDirectory </> "good")
     allBadJavas <- getAllJavaPaths (testJavaDirectory </> "bad")
 
@@ -65,6 +65,6 @@ main = do
         [ testGroup "parsing unit good" (map (toTestCase True) allGoodJavas)
         , testGroup "parsing unit bad" (map (toTestCase False) allBadJavas)
         , testProperty "parsing.generating==id" (\g -> case parser compilationUnit (show $ pretty g) of
-                                                            Right g'  -> g == g'
+                                                            Right g'  -> g == void g'
                                                             Left perr -> error (show (pretty g) ++ show perr))
         ]

--- a/tests/java/good/ReactiveTransactionManager.java
+++ b/tests/java/good/ReactiveTransactionManager.java
@@ -1,0 +1,1001 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.transaction.reactive;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.lang.Nullable;
+import org.springframework.transaction.IllegalTransactionStateException;
+import org.springframework.transaction.InvalidTimeoutException;
+import org.springframework.transaction.ReactiveTransaction;
+import org.springframework.transaction.ReactiveTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionSuspensionNotSupportedException;
+import org.springframework.transaction.UnexpectedRollbackException;
+
+/**
+ * Abstract base class that implements Spring's standard reactive transaction workflow,
+ * serving as basis for concrete platform transaction managers.
+ *
+ * <p>This base class provides the following workflow handling:
+ * <ul>
+ * <li>determines if there is an existing transaction;
+ * <li>applies the appropriate propagation behavior;
+ * <li>suspends and resumes transactions if necessary;
+ * <li>checks the rollback-only flag on commit;
+ * <li>applies the appropriate modification on rollback
+ * (actual rollback or setting rollback-only);
+ * <li>triggers registered synchronization callbacks.
+ * </ul>
+ *
+ * <p>Subclasses have to implement specific template methods for specific
+ * states of a transaction, e.g.: begin, suspend, resume, commit, rollback.
+ * The most important of them are abstract and must be provided by a concrete
+ * implementation; for the rest, defaults are provided, so overriding is optional.
+ *
+ * <p>Transaction synchronization is a generic mechanism for registering callbacks
+ * that get invoked at transaction completion time. This is mainly used internally
+ * by the data access support classes for R2DBC, MongoDB, etc. The same mechanism can
+ * also be leveraged for custom synchronization needs in an application.
+ *
+ * <p>The state of this class is serializable, to allow for serializing the
+ * transaction strategy along with proxies that carry a transaction interceptor.
+ * It is up to subclasses if they wish to make their state to be serializable too.
+ * They should implement the {@code java.io.Serializable} marker interface in
+ * that case, and potentially a private {@code readObject()} method (according
+ * to Java serialization rules) if they need to restore any transient state.
+ *
+ * @author Mark Paluch
+ * @author Juergen Hoeller
+ * @since 5.2
+ * @see TransactionSynchronizationManager
+ */
+@SuppressWarnings("serial")
+public abstract class AbstractReactiveTransactionManager implements ReactiveTransactionManager, Serializable {
+
+	protected transient Log logger = LogFactory.getLog(getClass());
+
+
+	//---------------------------------------------------------------------
+	// Implementation of ReactiveTransactionManager
+	//---------------------------------------------------------------------
+
+	/**
+	 * This implementation handles propagation behavior. Delegates to
+	 * {@code doGetTransaction}, {@code isExistingTransaction}
+	 * and {@code doBegin}.
+	 * @see #doGetTransaction
+	 * @see #isExistingTransaction
+	 * @see #doBegin
+	 */
+	@Override
+	public final Mono<ReactiveTransaction> getReactiveTransaction(@Nullable TransactionDefinition definition)
+			throws TransactionException {
+
+		// Use defaults if no transaction definition given.
+		TransactionDefinition def = (definition != null ? definition : TransactionDefinition.withDefaults());
+
+		return TransactionSynchronizationManager.forCurrentTransaction()
+				.flatMap(synchronizationManager -> {
+
+			Object transaction = doGetTransaction(synchronizationManager);
+
+			// Cache debug flag to avoid repeated checks.
+			boolean debugEnabled = logger.isDebugEnabled();
+
+			if (isExistingTransaction(transaction)) {
+				// Existing transaction found -> check propagation behavior to find out how to behave.
+				return handleExistingTransaction(synchronizationManager, def, transaction, debugEnabled);
+			}
+
+			// Check definition settings for new transaction.
+			if (def.getTimeout() < TransactionDefinition.TIMEOUT_DEFAULT) {
+				return Mono.error(new InvalidTimeoutException("Invalid transaction timeout", def.getTimeout()));
+			}
+
+			// No existing transaction found -> check propagation behavior to find out how to proceed.
+			if (def.getPropagationBehavior() == TransactionDefinition.PROPAGATION_MANDATORY) {
+				return Mono.error(new IllegalTransactionStateException(
+						"No existing transaction found for transaction marked with propagation 'mandatory'"));
+			}
+			else if (def.getPropagationBehavior() == TransactionDefinition.PROPAGATION_REQUIRED ||
+					def.getPropagationBehavior() == TransactionDefinition.PROPAGATION_REQUIRES_NEW ||
+					def.getPropagationBehavior() == TransactionDefinition.PROPAGATION_NESTED) {
+
+				return TransactionContextManager.currentContext()
+						.map(TransactionSynchronizationManager::new)
+						.flatMap(nestedSynchronizationManager ->
+								suspend(nestedSynchronizationManager, null)
+								.map(Optional::of)
+								.defaultIfEmpty(Optional.empty())
+								.flatMap(suspendedResources -> {
+							if (debugEnabled) {
+								logger.debug("Creating new transaction with name [" + def.getName() + "]: " + def);
+							}
+							return Mono.defer(() -> {
+								GenericReactiveTransaction status = newReactiveTransaction(
+										nestedSynchronizationManager, def, transaction, true,
+										debugEnabled, suspendedResources.orElse(null));
+								return doBegin(nestedSynchronizationManager, transaction, def)
+										.doOnSuccess(ignore -> prepareSynchronization(nestedSynchronizationManager, status, def))
+										.thenReturn(status);
+							}).onErrorResume(ErrorPredicates.RUNTIME_OR_ERROR,
+									ex -> resume(nestedSynchronizationManager, null, suspendedResources.orElse(null))
+									.then(Mono.error(ex)));
+						}));
+			}
+			else {
+				// Create "empty" transaction: no actual transaction, but potentially synchronization.
+				if (def.getIsolationLevel() != TransactionDefinition.ISOLATION_DEFAULT && logger.isWarnEnabled()) {
+					logger.warn("Custom isolation level specified but no actual transaction initiated; " +
+							"isolation level will effectively be ignored: " + def);
+				}
+				return Mono.just(prepareReactiveTransaction(synchronizationManager, def, null, true, debugEnabled, null));
+			}
+		});
+	}
+
+	/**
+	 * Create a ReactiveTransaction for an existing transaction.
+	 */
+	private Mono<ReactiveTransaction> handleExistingTransaction(TransactionSynchronizationManager synchronizationManager,
+			TransactionDefinition definition, Object transaction, boolean debugEnabled) throws TransactionException {
+
+		if (definition.getPropagationBehavior() == TransactionDefinition.PROPAGATION_NEVER) {
+			return Mono.error(new IllegalTransactionStateException(
+					"Existing transaction found for transaction marked with propagation 'never'"));
+		}
+
+		if (definition.getPropagationBehavior() == TransactionDefinition.PROPAGATION_NOT_SUPPORTED) {
+			if (debugEnabled) {
+				logger.debug("Suspending current transaction");
+			}
+			Mono<SuspendedResourcesHolder> suspend = suspend(synchronizationManager, transaction);
+			return suspend.map(suspendedResources -> prepareReactiveTransaction(synchronizationManager,
+					definition, null, false, debugEnabled, suspendedResources)) //
+					.switchIfEmpty(Mono.fromSupplier(() -> prepareReactiveTransaction(synchronizationManager,
+							definition, null, false, debugEnabled, null)))
+					.cast(ReactiveTransaction.class);
+		}
+
+		if (definition.getPropagationBehavior() == TransactionDefinition.PROPAGATION_REQUIRES_NEW) {
+			if (debugEnabled) {
+				logger.debug("Suspending current transaction, creating new transaction with name [" +
+						definition.getName() + "]");
+			}
+			Mono<SuspendedResourcesHolder> suspendedResources = suspend(synchronizationManager, transaction);
+			return suspendedResources.flatMap(suspendedResourcesHolder -> {
+				GenericReactiveTransaction status = newReactiveTransaction(synchronizationManager,
+						definition, transaction, true, debugEnabled, suspendedResourcesHolder);
+				return doBegin(synchronizationManager, transaction, definition).doOnSuccess(ignore ->
+						prepareSynchronization(synchronizationManager, status, definition)).thenReturn(status)
+						.onErrorResume(ErrorPredicates.RUNTIME_OR_ERROR, beginEx ->
+								resumeAfterBeginException(synchronizationManager, transaction, suspendedResourcesHolder, beginEx).then(Mono.error(beginEx)));
+			});
+		}
+
+		if (definition.getPropagationBehavior() == TransactionDefinition.PROPAGATION_NESTED) {
+			if (debugEnabled) {
+				logger.debug("Creating nested transaction with name [" + definition.getName() + "]");
+			}
+			// Nested transaction through nested begin and commit/rollback calls.
+			GenericReactiveTransaction status = newReactiveTransaction(synchronizationManager,
+					definition, transaction, true, debugEnabled, null);
+			return doBegin(synchronizationManager, transaction, definition).doOnSuccess(ignore ->
+					prepareSynchronization(synchronizationManager, status, definition)).thenReturn(status);
+		}
+
+		// Assumably PROPAGATION_SUPPORTS or PROPAGATION_REQUIRED.
+		if (debugEnabled) {
+			logger.debug("Participating in existing transaction");
+		}
+		return Mono.just(prepareReactiveTransaction(synchronizationManager, definition, transaction, false, debugEnabled, null));
+	}
+
+	/**
+	 * Create a new ReactiveTransaction for the given arguments,
+	 * also initializing transaction synchronization as appropriate.
+	 * @see #newReactiveTransaction
+	 * @see #prepareReactiveTransaction
+	 */
+	private GenericReactiveTransaction prepareReactiveTransaction(
+			TransactionSynchronizationManager synchronizationManager, TransactionDefinition definition,
+			@Nullable Object transaction, boolean newTransaction, boolean debug, @Nullable Object suspendedResources) {
+
+		GenericReactiveTransaction status = newReactiveTransaction(synchronizationManager,
+				definition, transaction, newTransaction, debug, suspendedResources);
+		prepareSynchronization(synchronizationManager, status, definition);
+		return status;
+	}
+
+	/**
+	 * Create a ReactiveTransaction instance for the given arguments.
+	 */
+	private GenericReactiveTransaction newReactiveTransaction(
+			TransactionSynchronizationManager synchronizationManager, TransactionDefinition definition,
+			@Nullable Object transaction, boolean newTransaction, boolean debug, @Nullable Object suspendedResources) {
+
+		return new GenericReactiveTransaction(transaction, newTransaction,
+				!synchronizationManager.isSynchronizationActive(),
+				definition.isReadOnly(), debug, suspendedResources);
+	}
+
+	/**
+	 * Initialize transaction synchronization as appropriate.
+	 */
+	private void prepareSynchronization(TransactionSynchronizationManager synchronizationManager,
+			GenericReactiveTransaction status, TransactionDefinition definition) {
+
+		if (status.isNewSynchronization()) {
+			synchronizationManager.setActualTransactionActive(status.hasTransaction());
+			synchronizationManager.setCurrentTransactionIsolationLevel(
+					definition.getIsolationLevel() != TransactionDefinition.ISOLATION_DEFAULT ?
+							definition.getIsolationLevel() : null);
+			synchronizationManager.setCurrentTransactionReadOnly(definition.isReadOnly());
+			synchronizationManager.setCurrentTransactionName(definition.getName());
+			synchronizationManager.initSynchronization();
+		}
+	}
+
+
+	/**
+	 * Suspend the given transaction. Suspends transaction synchronization first,
+	 * then delegates to the {@code doSuspend} template method.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param transaction the current transaction object
+	 * (or {@code null} to just suspend active synchronizations, if any)
+	 * @return an object that holds suspended resources
+	 * (or {@code null} if neither transaction nor synchronization active)
+	 * @see #doSuspend
+	 * @see #resume
+	 */
+	private Mono<SuspendedResourcesHolder> suspend(TransactionSynchronizationManager synchronizationManager,
+			@Nullable Object transaction) throws TransactionException {
+
+		if (synchronizationManager.isSynchronizationActive()) {
+			Mono<List<TransactionSynchronization>> suspendedSynchronizations = doSuspendSynchronization(synchronizationManager);
+			return suspendedSynchronizations.flatMap(synchronizations -> {
+				Mono<Optional<Object>> suspendedResources = (transaction != null ? doSuspend(synchronizationManager, transaction).map(Optional::of).defaultIfEmpty(Optional.empty()) : Mono.just(Optional.empty()));
+				return suspendedResources.map(it -> {
+					String name = synchronizationManager.getCurrentTransactionName();
+					synchronizationManager.setCurrentTransactionName(null);
+					boolean readOnly = synchronizationManager.isCurrentTransactionReadOnly();
+					synchronizationManager.setCurrentTransactionReadOnly(false);
+					Integer isolationLevel = synchronizationManager.getCurrentTransactionIsolationLevel();
+					synchronizationManager.setCurrentTransactionIsolationLevel(null);
+					boolean wasActive = synchronizationManager.isActualTransactionActive();
+					synchronizationManager.setActualTransactionActive(false);
+					return new SuspendedResourcesHolder(
+							it.orElse(null), synchronizations, name, readOnly, isolationLevel, wasActive);
+				}).onErrorResume(ErrorPredicates.RUNTIME_OR_ERROR, ex -> doResumeSynchronization(synchronizationManager, synchronizations).cast(SuspendedResourcesHolder.class));
+			});
+		}
+		else if (transaction != null) {
+			// Transaction active but no synchronization active.
+			Mono<Optional<Object>> suspendedResources = doSuspend(synchronizationManager, transaction).map(Optional::of).defaultIfEmpty(Optional.empty());
+			return suspendedResources.map(it -> new SuspendedResourcesHolder(it.orElse(null)));
+		}
+		else {
+			// Neither transaction nor synchronization active.
+			return Mono.empty();
+		}
+	}
+
+	/**
+	 * Resume the given transaction. Delegates to the {@code doResume}
+	 * template method first, then resuming transaction synchronization.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param transaction the current transaction object
+	 * @param resourcesHolder the object that holds suspended resources,
+	 * as returned by {@code suspend} (or {@code null} to just
+	 * resume synchronizations, if any)
+	 * @see #doResume
+	 * @see #suspend
+	 */
+	private Mono<Void> resume(TransactionSynchronizationManager synchronizationManager,
+			@Nullable Object transaction, @Nullable SuspendedResourcesHolder resourcesHolder)
+			throws TransactionException {
+
+		Mono<Void> resume = Mono.empty();
+
+		if (resourcesHolder != null) {
+			Object suspendedResources = resourcesHolder.suspendedResources;
+			if (suspendedResources != null) {
+				resume =  doResume(synchronizationManager, transaction, suspendedResources);
+			}
+			List<TransactionSynchronization> suspendedSynchronizations = resourcesHolder.suspendedSynchronizations;
+			if (suspendedSynchronizations != null) {
+				synchronizationManager.setActualTransactionActive(resourcesHolder.wasActive);
+				synchronizationManager.setCurrentTransactionIsolationLevel(resourcesHolder.isolationLevel);
+				synchronizationManager.setCurrentTransactionReadOnly(resourcesHolder.readOnly);
+				synchronizationManager.setCurrentTransactionName(resourcesHolder.name);
+				return resume.then(doResumeSynchronization(synchronizationManager, suspendedSynchronizations));
+			}
+		}
+
+		return resume;
+	}
+
+	/**
+	 * Resume outer transaction after inner transaction begin failed.
+	 */
+	private Mono<Void> resumeAfterBeginException(TransactionSynchronizationManager synchronizationManager,
+			Object transaction, @Nullable SuspendedResourcesHolder suspendedResources, Throwable beginEx) {
+
+		String exMessage = "Inner transaction begin exception overridden by outer transaction resume exception";
+		return resume(synchronizationManager, transaction, suspendedResources).doOnError(ErrorPredicates.RUNTIME_OR_ERROR,
+				ex -> logger.error(exMessage, beginEx));
+	}
+
+	/**
+	 * Suspend all current synchronizations and deactivate transaction
+	 * synchronization for the current transaction context.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @return the List of suspended TransactionSynchronization objects
+	 */
+	private Mono<List<TransactionSynchronization>> doSuspendSynchronization(
+			TransactionSynchronizationManager synchronizationManager) {
+
+		List<TransactionSynchronization> suspendedSynchronizations = synchronizationManager.getSynchronizations();
+		return Flux.fromIterable(suspendedSynchronizations)
+				.concatMap(TransactionSynchronization::suspend)
+				.then(Mono.defer(() -> {
+					synchronizationManager.clearSynchronization();
+					return Mono.just(suspendedSynchronizations);
+				}));
+	}
+
+	/**
+	 * Reactivate transaction synchronization for the current transaction context
+	 * and resume all given synchronizations.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param suspendedSynchronizations a List of TransactionSynchronization objects
+	 */
+	private Mono<Void> doResumeSynchronization(TransactionSynchronizationManager synchronizationManager,
+			List<TransactionSynchronization> suspendedSynchronizations) {
+
+		synchronizationManager.initSynchronization();
+		return Flux.fromIterable(suspendedSynchronizations)
+				.concatMap(synchronization -> synchronization.resume()
+						.doOnSuccess(ignore -> synchronizationManager.registerSynchronization(synchronization))).then();
+	}
+
+
+	/**
+	 * This implementation of commit handles participating in existing
+	 * transactions and programmatic rollback requests.
+	 * Delegates to {@code isRollbackOnly}, {@code doCommit}
+	 * and {@code rollback}.
+	 * @see ReactiveTransaction#isRollbackOnly()
+	 * @see #doCommit
+	 * @see #rollback
+	 */
+	@Override
+	public final Mono<Void> commit(ReactiveTransaction transaction) throws TransactionException {
+		if (transaction.isCompleted()) {
+			return Mono.error(new IllegalTransactionStateException(
+					"Transaction is already completed - do not call commit or rollback more than once per transaction"));
+		}
+
+		return TransactionSynchronizationManager.forCurrentTransaction().flatMap(synchronizationManager -> {
+			GenericReactiveTransaction reactiveTx = (GenericReactiveTransaction) transaction;
+			if (reactiveTx.isRollbackOnly()) {
+				if (reactiveTx.isDebug()) {
+					logger.debug("Transactional code has requested rollback");
+				}
+				return processRollback(synchronizationManager, reactiveTx);
+			}
+			return processCommit(synchronizationManager, reactiveTx);
+		});
+	}
+
+	/**
+	 * Process an actual commit.
+	 * Rollback-only flags have already been checked and applied.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param status object representing the transaction
+	 * @throws TransactionException in case of commit failure
+	 */
+	private Mono<Void> processCommit(TransactionSynchronizationManager synchronizationManager,
+			GenericReactiveTransaction status) throws TransactionException {
+
+		AtomicBoolean beforeCompletionInvoked = new AtomicBoolean(false);
+
+		Mono<Object> commit = prepareForCommit(synchronizationManager, status)
+				.then(triggerBeforeCommit(synchronizationManager, status))
+				.then(triggerBeforeCompletion(synchronizationManager, status))
+				.then(Mono.defer(() -> {
+					beforeCompletionInvoked.set(true);
+					if (status.isNewTransaction()) {
+						if (status.isDebug()) {
+							logger.debug("Initiating transaction commit");
+						}
+						return doCommit(synchronizationManager, status);
+					}
+					return Mono.empty();
+				})).then(Mono.empty().onErrorResume(ex -> {
+					Mono<Object> propagateException = Mono.error(ex);
+					// Store result in a local variable in order to appease the
+					// Eclipse compiler with regard to inferred generics.
+					Mono<Object> result = propagateException;
+					if (ErrorPredicates.UNEXPECTED_ROLLBACK.test(ex)) {
+						result = triggerAfterCompletion(synchronizationManager, status, TransactionSynchronization.STATUS_ROLLED_BACK).then(propagateException);
+					}
+					else if (ErrorPredicates.TRANSACTION_EXCEPTION.test(ex)) {
+						result = triggerAfterCompletion(synchronizationManager, status, TransactionSynchronization.STATUS_UNKNOWN).then(propagateException);
+					}
+					else if (ErrorPredicates.RUNTIME_OR_ERROR.test(ex)) {
+						Mono<Void> mono;
+						if (!beforeCompletionInvoked.get()) {
+							mono = triggerBeforeCompletion(synchronizationManager, status);
+						}
+						else {
+							mono = Mono.empty();
+						}
+						result = mono.then(doRollbackOnCommitException(synchronizationManager, status, ex)).then(propagateException);
+					}
+
+					return result;
+				})).then(Mono.defer(() -> triggerAfterCommit(synchronizationManager, status).onErrorResume(ex ->
+						triggerAfterCompletion(synchronizationManager, status, TransactionSynchronization.STATUS_COMMITTED).then(Mono.error(ex)))
+						.then(triggerAfterCompletion(synchronizationManager, status, TransactionSynchronization.STATUS_COMMITTED))));
+
+		return commit
+				.onErrorResume(ex -> cleanupAfterCompletion(synchronizationManager, status)
+						.then(Mono.error(ex))).then(cleanupAfterCompletion(synchronizationManager, status));
+	}
+
+	/**
+	 * This implementation of rollback handles participating in existing transactions.
+	 * Delegates to {@code doRollback} and {@code doSetRollbackOnly}.
+	 * @see #doRollback
+	 * @see #doSetRollbackOnly
+	 */
+	@Override
+	public final Mono<Void> rollback(ReactiveTransaction transaction) throws TransactionException {
+		if (transaction.isCompleted()) {
+			return Mono.error(new IllegalTransactionStateException(
+					"Transaction is already completed - do not call commit or rollback more than once per transaction"));
+		}
+		return TransactionSynchronizationManager.forCurrentTransaction().flatMap(synchronizationManager -> {
+			GenericReactiveTransaction reactiveTx = (GenericReactiveTransaction) transaction;
+			return processRollback(synchronizationManager, reactiveTx);
+		});
+	}
+
+	/**
+	 * Process an actual rollback.
+	 * The completed flag has already been checked.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param status object representing the transaction
+	 * @throws TransactionException in case of rollback failure
+	 */
+	private Mono<Void> processRollback(TransactionSynchronizationManager synchronizationManager,
+			GenericReactiveTransaction status) {
+
+		return triggerBeforeCompletion(synchronizationManager, status).then(Mono.defer(() -> {
+			if (status.isNewTransaction()) {
+				if (status.isDebug()) {
+					logger.debug("Initiating transaction rollback");
+				}
+				return doRollback(synchronizationManager, status);
+			}
+			else {
+				Mono<Void> beforeCompletion = Mono.empty();
+				// Participating in larger transaction
+				if (status.hasTransaction()) {
+					if (status.isDebug()) {
+						logger.debug("Participating transaction failed - marking existing transaction as rollback-only");
+					}
+					beforeCompletion = doSetRollbackOnly(synchronizationManager, status);
+				}
+				else {
+					logger.debug("Should roll back transaction but cannot - no transaction available");
+				}
+				return beforeCompletion;
+			}
+		})).onErrorResume(ErrorPredicates.RUNTIME_OR_ERROR, ex -> triggerAfterCompletion(
+				synchronizationManager, status, TransactionSynchronization.STATUS_UNKNOWN)
+				.then(Mono.error(ex)))
+				.then(Mono.defer(() -> triggerAfterCompletion(synchronizationManager, status, TransactionSynchronization.STATUS_ROLLED_BACK)))
+				.onErrorResume(ex -> cleanupAfterCompletion(synchronizationManager, status).then(Mono.error(ex)))
+			.then(cleanupAfterCompletion(synchronizationManager, status));
+	}
+
+	/**
+	 * Invoke {@code doRollback}, handling rollback exceptions properly.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param status object representing the transaction
+	 * @param ex the thrown application exception or error
+	 * @throws TransactionException in case of rollback failure
+	 * @see #doRollback
+	 */
+	private Mono<Void> doRollbackOnCommitException(TransactionSynchronizationManager synchronizationManager,
+			GenericReactiveTransaction status, Throwable ex) throws TransactionException {
+
+		return Mono.defer(() -> {
+			if (status.isNewTransaction()) {
+				if (status.isDebug()) {
+					logger.debug("Initiating transaction rollback after commit exception", ex);
+				}
+				return doRollback(synchronizationManager, status);
+			}
+			else if (status.hasTransaction()) {
+				if (status.isDebug()) {
+					logger.debug("Marking existing transaction as rollback-only after commit exception", ex);
+				}
+				return doSetRollbackOnly(synchronizationManager, status);
+			}
+			return Mono.empty();
+		}).onErrorResume(ErrorPredicates.RUNTIME_OR_ERROR, rbex -> {
+			logger.error("Commit exception overridden by rollback exception", ex);
+			return triggerAfterCompletion(synchronizationManager, status, TransactionSynchronization.STATUS_UNKNOWN)
+				.then(Mono.error(rbex));
+		}).then(triggerAfterCompletion(synchronizationManager, status, TransactionSynchronization.STATUS_ROLLED_BACK));
+	}
+
+
+	/**
+	 * Trigger {@code beforeCommit} callbacks.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param status object representing the transaction
+	 */
+	private Mono<Void> triggerBeforeCommit(TransactionSynchronizationManager synchronizationManager,
+			GenericReactiveTransaction status) {
+
+		if (status.isNewSynchronization()) {
+			if (status.isDebug()) {
+				logger.trace("Triggering beforeCommit synchronization");
+			}
+			return TransactionSynchronizationUtils.triggerBeforeCommit(synchronizationManager.getSynchronizations(), status.isReadOnly());
+		}
+
+		return Mono.empty();
+	}
+
+	/**
+	 * Trigger {@code beforeCompletion} callbacks.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param status object representing the transaction
+	 */
+	private Mono<Void> triggerBeforeCompletion(TransactionSynchronizationManager synchronizationManager,
+			GenericReactiveTransaction status) {
+
+		if (status.isNewSynchronization()) {
+			if (status.isDebug()) {
+				logger.trace("Triggering beforeCompletion synchronization");
+			}
+			return TransactionSynchronizationUtils.triggerBeforeCompletion(synchronizationManager.getSynchronizations());
+		}
+
+		return Mono.empty();
+	}
+
+	/**
+	 * Trigger {@code afterCommit} callbacks.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param status object representing the transaction
+	 */
+	private Mono<Void> triggerAfterCommit(TransactionSynchronizationManager synchronizationManager,
+			GenericReactiveTransaction status) {
+
+		if (status.isNewSynchronization()) {
+			if (status.isDebug()) {
+				logger.trace("Triggering afterCommit synchronization");
+			}
+			return TransactionSynchronizationUtils.invokeAfterCommit(synchronizationManager.getSynchronizations());
+		}
+
+		return Mono.empty();
+	}
+
+	/**
+	 * Trigger {@code afterCompletion} callbacks.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param status object representing the transaction
+	 * @param completionStatus completion status according to TransactionSynchronization constants
+	 */
+	private Mono<Void> triggerAfterCompletion(TransactionSynchronizationManager synchronizationManager,
+			GenericReactiveTransaction status, int completionStatus) {
+
+		if (status.isNewSynchronization()) {
+			List<TransactionSynchronization> synchronizations = synchronizationManager.getSynchronizations();
+			synchronizationManager.clearSynchronization();
+			if (!status.hasTransaction() || status.isNewTransaction()) {
+				if (status.isDebug()) {
+					logger.trace("Triggering afterCompletion synchronization");
+				}
+				// No transaction or new transaction for the current scope ->
+				// invoke the afterCompletion callbacks immediately
+				return invokeAfterCompletion(synchronizationManager, synchronizations, completionStatus);
+			}
+			else if (!synchronizations.isEmpty()) {
+				// Existing transaction that we participate in, controlled outside
+				// of the scope of this Spring transaction manager -> try to register
+				// an afterCompletion callback with the existing (JTA) transaction.
+				return registerAfterCompletionWithExistingTransaction(synchronizationManager, status.getTransaction(), synchronizations);
+			}
+		}
+
+		return Mono.empty();
+	}
+
+	/**
+	 * Actually invoke the {@code afterCompletion} methods of the
+	 * given TransactionSynchronization objects.
+	 * <p>To be called by this abstract manager itself, or by special implementations
+	 * of the {@code registerAfterCompletionWithExistingTransaction} callback.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param synchronizations a List of TransactionSynchronization objects
+	 * @param completionStatus the completion status according to the
+	 * constants in the TransactionSynchronization interface
+	 * @see #registerAfterCompletionWithExistingTransaction(TransactionSynchronizationManager, Object, List)
+	 * @see TransactionSynchronization#STATUS_COMMITTED
+	 * @see TransactionSynchronization#STATUS_ROLLED_BACK
+	 * @see TransactionSynchronization#STATUS_UNKNOWN
+	 */
+	private Mono<Void> invokeAfterCompletion(TransactionSynchronizationManager synchronizationManager,
+			List<TransactionSynchronization> synchronizations, int completionStatus) {
+
+		return TransactionSynchronizationUtils.invokeAfterCompletion(synchronizations, completionStatus);
+	}
+
+	/**
+	 * Clean up after completion, clearing synchronization if necessary,
+	 * and invoking doCleanupAfterCompletion.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param status object representing the transaction
+	 * @see #doCleanupAfterCompletion
+	 */
+	private Mono<Void> cleanupAfterCompletion(TransactionSynchronizationManager synchronizationManager,
+			GenericReactiveTransaction status) {
+
+		return Mono.defer(() -> {
+			status.setCompleted();
+			if (status.isNewSynchronization()) {
+				synchronizationManager.clear();
+			}
+			Mono<Void> cleanup = Mono.empty();
+			if (status.isNewTransaction()) {
+				cleanup = doCleanupAfterCompletion(synchronizationManager, status.getTransaction());
+			}
+			if (status.getSuspendedResources() != null) {
+				if (status.isDebug()) {
+					logger.debug("Resuming suspended transaction after completion of inner transaction");
+				}
+				Object transaction = (status.hasTransaction() ? status.getTransaction() : null);
+				return cleanup.then(resume(synchronizationManager, transaction, (SuspendedResourcesHolder) status.getSuspendedResources()));
+			}
+			return cleanup;
+		});
+	}
+
+
+	//---------------------------------------------------------------------
+	// Template methods to be implemented in subclasses
+	//---------------------------------------------------------------------
+
+	/**
+	 * Return a transaction object for the current transaction state.
+	 * <p>The returned object will usually be specific to the concrete transaction
+	 * manager implementation, carrying corresponding transaction state in a
+	 * modifiable fashion. This object will be passed into the other template
+	 * methods (e.g. doBegin and doCommit), either directly or as part of a
+	 * DefaultReactiveTransactionStatus instance.
+	 * <p>The returned object should contain information about any existing
+	 * transaction, that is, a transaction that has already started before the
+	 * current {@code getTransaction} call on the transaction manager.
+	 * Consequently, a {@code doGetTransaction} implementation will usually
+	 * look for an existing transaction and store corresponding state in the
+	 * returned transaction object.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @return the current transaction object
+	 * @throws org.springframework.transaction.CannotCreateTransactionException if transaction support is not available
+	 * @throws TransactionException in case of lookup or system errors
+	 * @see #doBegin
+	 * @see #doCommit
+	 * @see #doRollback
+	 * @see GenericReactiveTransaction#getTransaction
+	 */
+	protected abstract Object doGetTransaction(TransactionSynchronizationManager synchronizationManager) throws TransactionException;
+
+	/**
+	 * Check if the given transaction object indicates an existing transaction
+	 * (that is, a transaction which has already started).
+	 * <p>The result will be evaluated according to the specified propagation
+	 * behavior for the new transaction. An existing transaction might get
+	 * suspended (in case of PROPAGATION_REQUIRES_NEW), or the new transaction
+	 * might participate in the existing one (in case of PROPAGATION_REQUIRED).
+	 * <p>The default implementation returns {@code false}, assuming that
+	 * participating in existing transactions is generally not supported.
+	 * Subclasses are of course encouraged to provide such support.
+	 * @param transaction transaction object returned by doGetTransaction
+	 * @return if there is an existing transaction
+	 * @throws TransactionException in case of system errors
+	 * @see #doGetTransaction
+	 */
+	protected boolean isExistingTransaction(Object transaction) throws TransactionException {
+		return false;
+	}
+
+	/**
+	 * Begin a new transaction with semantics according to the given transaction
+	 * definition. Does not have to care about applying the propagation behavior,
+	 * as this has already been handled by this abstract manager.
+	 * <p>This method gets called when the transaction manager has decided to actually
+	 * start a new transaction. Either there wasn't any transaction before, or the
+	 * previous transaction has been suspended.
+	 * <p>A special scenario is a nested transaction: This method will be called to
+	 * start a nested transaction when necessary. In such a context, there will be an
+	 * active transaction: The implementation of this method has to detect this and
+	 * start an appropriate nested transaction.
+	 * @param synchronizationManager the synchronization manager bound to the new transaction
+	 * @param transaction transaction object returned by {@code doGetTransaction}
+	 * @param definition a TransactionDefinition instance, describing propagation
+	 * behavior, isolation level, read-only flag, timeout, and transaction name
+	 * @throws TransactionException in case of creation or system errors
+	 * @throws org.springframework.transaction.NestedTransactionNotSupportedException
+	 * if the underlying transaction does not support nesting (e.g. through savepoints)
+	 */
+	protected abstract Mono<Void> doBegin(TransactionSynchronizationManager synchronizationManager,
+			Object transaction, TransactionDefinition definition) throws TransactionException;
+
+	/**
+	 * Suspend the resources of the current transaction.
+	 * Transaction synchronization will already have been suspended.
+	 * <p>The default implementation throws a TransactionSuspensionNotSupportedException,
+	 * assuming that transaction suspension is generally not supported.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param transaction transaction object returned by {@code doGetTransaction}
+	 * @return an object that holds suspended resources
+	 * (will be kept unexamined for passing it into doResume)
+	 * @throws org.springframework.transaction.TransactionSuspensionNotSupportedException if suspending is not supported by the transaction manager implementation
+	 * @throws TransactionException in case of system errors
+	 * @see #doResume
+	 */
+	protected Mono<Object> doSuspend(TransactionSynchronizationManager synchronizationManager,
+			Object transaction) throws TransactionException {
+
+		throw new TransactionSuspensionNotSupportedException(
+				"Transaction manager [" + getClass().getName() + "] does not support transaction suspension");
+	}
+
+	/**
+	 * Resume the resources of the current transaction.
+	 * Transaction synchronization will be resumed afterwards.
+	 * <p>The default implementation throws a TransactionSuspensionNotSupportedException,
+	 * assuming that transaction suspension is generally not supported.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param transaction transaction object returned by {@code doGetTransaction}
+	 * @param suspendedResources the object that holds suspended resources,
+	 * as returned by doSuspend
+	 * @throws org.springframework.transaction.TransactionSuspensionNotSupportedException if resuming is not supported by the transaction manager implementation
+	 * @throws TransactionException in case of system errors
+	 * @see #doSuspend
+	 */
+	protected Mono<Void> doResume(TransactionSynchronizationManager synchronizationManager,
+			@Nullable Object transaction, Object suspendedResources) throws TransactionException {
+
+		throw new TransactionSuspensionNotSupportedException(
+				"Transaction manager [" + getClass().getName() + "] does not support transaction suspension");
+	}
+
+	/**
+	 * Make preparations for commit, to be performed before the
+	 * {@code beforeCommit} synchronization callbacks occur.
+	 * <p>Note that exceptions will get propagated to the commit caller
+	 * and cause a rollback of the transaction.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param status the status representation of the transaction
+	 * @throws RuntimeException in case of errors; will be <b>propagated to the caller</b>
+	 * (note: do not throw TransactionException subclasses here!)
+	 */
+	protected Mono<Void> prepareForCommit(TransactionSynchronizationManager synchronizationManager,
+			GenericReactiveTransaction status) {
+
+		return Mono.empty();
+	}
+
+	/**
+	 * Perform an actual commit of the given transaction.
+	 * <p>An implementation does not need to check the "new transaction" flag
+	 * or the rollback-only flag; this will already have been handled before.
+	 * Usually, a straight commit will be performed on the transaction object
+	 * contained in the passed-in status.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param status the status representation of the transaction
+	 * @throws TransactionException in case of commit or system errors
+	 * @see GenericReactiveTransaction#getTransaction
+	 */
+	protected abstract Mono<Void> doCommit(TransactionSynchronizationManager synchronizationManager,
+			GenericReactiveTransaction status) throws TransactionException;
+
+	/**
+	 * Perform an actual rollback of the given transaction.
+	 * <p>An implementation does not need to check the "new transaction" flag;
+	 * this will already have been handled before. Usually, a straight rollback
+	 * will be performed on the transaction object contained in the passed-in status.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param status the status representation of the transaction
+	 * @throws TransactionException in case of system errors
+	 * @see GenericReactiveTransaction#getTransaction
+	 */
+	protected abstract Mono<Void> doRollback(TransactionSynchronizationManager synchronizationManager,
+			GenericReactiveTransaction status) throws TransactionException;
+
+	/**
+	 * Set the given transaction rollback-only. Only called on rollback
+	 * if the current transaction participates in an existing one.
+	 * <p>The default implementation throws an IllegalTransactionStateException,
+	 * assuming that participating in existing transactions is generally not
+	 * supported. Subclasses are of course encouraged to provide such support.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param status the status representation of the transaction
+	 * @throws TransactionException in case of system errors
+	 */
+	protected Mono<Void> doSetRollbackOnly(TransactionSynchronizationManager synchronizationManager,
+			GenericReactiveTransaction status) throws TransactionException {
+
+		throw new IllegalTransactionStateException(
+				"Participating in existing transactions is not supported - when 'isExistingTransaction' " +
+				"returns true, appropriate 'doSetRollbackOnly' behavior must be provided");
+	}
+
+	/**
+	 * Register the given list of transaction synchronizations with the existing transaction.
+	 * <p>Invoked when the control of the Spring transaction manager and thus all Spring
+	 * transaction synchronizations end, without the transaction being completed yet. This
+	 * is for example the case when participating in an existing JTA or EJB CMT transaction.
+	 * <p>The default implementation simply invokes the {@code afterCompletion} methods
+	 * immediately, passing in "STATUS_UNKNOWN". This is the best we can do if there's no
+	 * chance to determine the actual outcome of the outer transaction.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param transaction transaction object returned by {@code doGetTransaction}
+	 * @param synchronizations a List of TransactionSynchronization objects
+	 * @throws TransactionException in case of system errors
+	 * @see #invokeAfterCompletion(TransactionSynchronizationManager, List, int)
+	 * @see TransactionSynchronization#afterCompletion(int)
+	 * @see TransactionSynchronization#STATUS_UNKNOWN
+	 */
+	protected Mono<Void> registerAfterCompletionWithExistingTransaction(TransactionSynchronizationManager synchronizationManager,
+			Object transaction, List<TransactionSynchronization> synchronizations) throws TransactionException {
+
+		logger.debug("Cannot register Spring after-completion synchronization with existing transaction - " +
+				"processing Spring after-completion callbacks immediately, with outcome status 'unknown'");
+		return invokeAfterCompletion(synchronizationManager, synchronizations, TransactionSynchronization.STATUS_UNKNOWN);
+	}
+
+	/**
+	 * Cleanup resources after transaction completion.
+	 * <p>Called after {@code doCommit} and {@code doRollback} execution,
+	 * on any outcome. The default implementation does nothing.
+	 * <p>Should not throw any exceptions but just issue warnings on errors.
+	 * @param synchronizationManager the synchronization manager bound to the current transaction
+	 * @param transaction transaction object returned by {@code doGetTransaction}
+	 */
+	protected Mono<Void> doCleanupAfterCompletion(TransactionSynchronizationManager synchronizationManager,
+			Object transaction) {
+
+		return Mono.empty();
+	}
+
+
+	//---------------------------------------------------------------------
+	// Serialization support
+	//---------------------------------------------------------------------
+
+	private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
+		// Rely on default serialization; just initialize state after deserialization.
+		ois.defaultReadObject();
+
+		// Initialize transient fields.
+		this.logger = LogFactory.getLog(getClass());
+	}
+
+
+	/**
+	 * Holder for suspended resources.
+	 * Used internally by {@code suspend} and {@code resume}.
+	 */
+	protected static final class SuspendedResourcesHolder {
+
+		@Nullable
+		private final Object suspendedResources;
+
+		@Nullable
+		private List<TransactionSynchronization> suspendedSynchronizations;
+
+		@Nullable
+		private String name;
+
+		private boolean readOnly;
+
+		@Nullable
+		private Integer isolationLevel;
+
+		private boolean wasActive;
+
+		private SuspendedResourcesHolder(@Nullable Object suspendedResources) {
+			this.suspendedResources = suspendedResources;
+		}
+
+		private SuspendedResourcesHolder(
+				@Nullable Object suspendedResources, List<TransactionSynchronization> suspendedSynchronizations,
+				@Nullable String name, boolean readOnly, @Nullable Integer isolationLevel, boolean wasActive) {
+
+			this.suspendedResources = suspendedResources;
+			this.suspendedSynchronizations = suspendedSynchronizations;
+			this.name = name;
+			this.readOnly = readOnly;
+			this.isolationLevel = isolationLevel;
+			this.wasActive = wasActive;
+		}
+	}
+
+
+	/**
+	 * Predicates for exception types that transactional error handling applies to.
+	 */
+	private enum ErrorPredicates implements Predicate<Throwable> {
+
+		/**
+		 * Predicate matching {@link RuntimeException} or {@link Error}.
+		 */
+		RUNTIME_OR_ERROR {
+			@Override
+			public boolean test(Throwable throwable) {
+				return throwable instanceof RuntimeException || throwable instanceof Error;
+			}
+		},
+
+		/**
+		 * Predicate matching {@link TransactionException}.
+		 */
+		TRANSACTION_EXCEPTION {
+			@Override
+			public boolean test(Throwable throwable) {
+				return throwable instanceof TransactionException;
+			}
+		},
+
+		/**
+		 * Predicate matching {@link UnexpectedRollbackException}.
+		 */
+		UNEXPECTED_ROLLBACK {
+			@Override
+			public boolean test(Throwable throwable) {
+				return throwable instanceof UnexpectedRollbackException;
+			}
+		};
+
+		@Override
+		public abstract boolean test(Throwable throwable);
+	}
+
+}

--- a/tests/java/good/Transactional.java
+++ b/tests/java/good/Transactional.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.transaction.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.transaction.TransactionDefinition;
+
+/**
+ * Describes a transaction attribute on an individual method or on a class.
+ *
+ * <p>At the class level, this annotation applies as a default to all methods of
+ * the declaring class and its subclasses. Note that it does not apply to ancestor
+ * classes up the class hierarchy; methods need to be locally redeclared in order
+ * to participate in a subclass-level annotation.
+ *
+ * <p>This annotation type is generally directly comparable to Spring's
+ * {@link org.springframework.transaction.interceptor.RuleBasedTransactionAttribute}
+ * class, and in fact {@link AnnotationTransactionAttributeSource} will directly
+ * convert the data to the latter class, so that Spring's transaction support code
+ * does not have to know about annotations. If no rules are relevant to the exception,
+ * it will be treated like
+ * {@link org.springframework.transaction.interceptor.DefaultTransactionAttribute}
+ * (rolling back on {@link RuntimeException} and {@link Error} but not on checked
+ * exceptions).
+ *
+ * <p>For specific information about the semantics of this annotation's attributes,
+ * consult the {@link org.springframework.transaction.TransactionDefinition} and
+ * {@link org.springframework.transaction.interceptor.TransactionAttribute} javadocs.
+ *
+ * @author Colin Sampaleanu
+ * @author Juergen Hoeller
+ * @author Sam Brannen
+ * @since 1.2
+ * @see org.springframework.transaction.interceptor.TransactionAttribute
+ * @see org.springframework.transaction.interceptor.DefaultTransactionAttribute
+ * @see org.springframework.transaction.interceptor.RuleBasedTransactionAttribute
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+public @interface Transactional {
+
+	/**
+	 * Alias for {@link #transactionManager}.
+	 * @see #transactionManager
+	 */
+	@AliasFor("transactionManager")
+	String value() default "";
+
+	/**
+	 * A <em>qualifier</em> value for the specified transaction.
+	 * <p>May be used to determine the target transaction manager,
+	 * matching the qualifier value (or the bean name) of a specific
+	 * {@link org.springframework.transaction.PlatformTransactionManager}
+	 * bean definition.
+	 * @since 4.2
+	 * @see #value
+	 */
+	@AliasFor("value")
+	String transactionManager() default "";
+
+	/**
+	 * The transaction propagation type.
+	 * <p>Defaults to {@link Propagation#REQUIRED}.
+	 * @see org.springframework.transaction.interceptor.TransactionAttribute#getPropagationBehavior()
+	 */
+	Propagation propagation() default Propagation.REQUIRED;
+
+	/**
+	 * The transaction isolation level.
+	 * <p>Defaults to {@link Isolation#DEFAULT}.
+	 * <p>Exclusively designed for use with {@link Propagation#REQUIRED} or
+	 * {@link Propagation#REQUIRES_NEW} since it only applies to newly started
+	 * transactions. Consider switching the "validateExistingTransactions" flag to
+	 * "true" on your transaction manager if you'd like isolation level declarations
+	 * to get rejected when participating in an existing transaction with a different
+	 * isolation level.
+	 * @see org.springframework.transaction.interceptor.TransactionAttribute#getIsolationLevel()
+	 * @see org.springframework.transaction.support.AbstractPlatformTransactionManager#setValidateExistingTransaction
+	 */
+	Isolation isolation() default Isolation.DEFAULT;
+
+	/**
+	 * The timeout for this transaction (in seconds).
+	 * <p>Defaults to the default timeout of the underlying transaction system.
+	 * <p>Exclusively designed for use with {@link Propagation#REQUIRED} or
+	 * {@link Propagation#REQUIRES_NEW} since it only applies to newly started
+	 * transactions.
+	 * @see org.springframework.transaction.interceptor.TransactionAttribute#getTimeout()
+	 */
+	int timeout() default TransactionDefinition.TIMEOUT_DEFAULT;
+
+	/**
+	 * A boolean flag that can be set to {@code true} if the transaction is
+	 * effectively read-only, allowing for corresponding optimizations at runtime.
+	 * <p>Defaults to {@code false}.
+	 * <p>This just serves as a hint for the actual transaction subsystem;
+	 * it will <i>not necessarily</i> cause failure of write access attempts.
+	 * A transaction manager which cannot interpret the read-only hint will
+	 * <i>not</i> throw an exception when asked for a read-only transaction
+	 * but rather silently ignore the hint.
+	 * @see org.springframework.transaction.interceptor.TransactionAttribute#isReadOnly()
+	 * @see org.springframework.transaction.support.TransactionSynchronizationManager#isCurrentTransactionReadOnly()
+	 */
+	boolean readOnly() default false;
+
+	/**
+	 * Defines zero (0) or more exception {@link Class classes}, which must be
+	 * subclasses of {@link Throwable}, indicating which exception types must cause
+	 * a transaction rollback.
+	 * <p>By default, a transaction will be rolling back on {@link RuntimeException}
+	 * and {@link Error} but not on checked exceptions (business exceptions). See
+	 * {@link org.springframework.transaction.interceptor.DefaultTransactionAttribute#rollbackOn(Throwable)}
+	 * for a detailed explanation.
+	 * <p>This is the preferred way to construct a rollback rule (in contrast to
+	 * {@link #rollbackForClassName}), matching the exception class and its subclasses.
+	 * <p>Similar to {@link org.springframework.transaction.interceptor.RollbackRuleAttribute#RollbackRuleAttribute(Class clazz)}.
+	 * @see #rollbackForClassName
+	 * @see org.springframework.transaction.interceptor.DefaultTransactionAttribute#rollbackOn(Throwable)
+	 */
+	Class<? extends Throwable>[] rollbackFor() default {};
+
+	/**
+	 * Defines zero (0) or more exception names (for exceptions which must be a
+	 * subclass of {@link Throwable}), indicating which exception types must cause
+	 * a transaction rollback.
+	 * <p>This can be a substring of a fully qualified class name, with no wildcard
+	 * support at present. For example, a value of {@code "ServletException"} would
+	 * match {@code javax.servlet.ServletException} and its subclasses.
+	 * <p><b>NB:</b> Consider carefully how specific the pattern is and whether
+	 * to include package information (which isn't mandatory). For example,
+	 * {@code "Exception"} will match nearly anything and will probably hide other
+	 * rules. {@code "java.lang.Exception"} would be correct if {@code "Exception"}
+	 * were meant to define a rule for all checked exceptions. With more unusual
+	 * {@link Exception} names such as {@code "BaseBusinessException"} there is no
+	 * need to use a FQN.
+	 * <p>Similar to {@link org.springframework.transaction.interceptor.RollbackRuleAttribute#RollbackRuleAttribute(String exceptionName)}.
+	 * @see #rollbackFor
+	 * @see org.springframework.transaction.interceptor.DefaultTransactionAttribute#rollbackOn(Throwable)
+	 */
+	String[] rollbackForClassName() default {};
+
+	/**
+	 * Defines zero (0) or more exception {@link Class Classes}, which must be
+	 * subclasses of {@link Throwable}, indicating which exception types must
+	 * <b>not</b> cause a transaction rollback.
+	 * <p>This is the preferred way to construct a rollback rule (in contrast
+	 * to {@link #noRollbackForClassName}), matching the exception class and
+	 * its subclasses.
+	 * <p>Similar to {@link org.springframework.transaction.interceptor.NoRollbackRuleAttribute#NoRollbackRuleAttribute(Class clazz)}.
+	 * @see #noRollbackForClassName
+	 * @see org.springframework.transaction.interceptor.DefaultTransactionAttribute#rollbackOn(Throwable)
+	 */
+	Class<? extends Throwable>[] noRollbackFor() default {};
+
+	/**
+	 * Defines zero (0) or more exception names (for exceptions which must be a
+	 * subclass of {@link Throwable}) indicating which exception types must <b>not</b>
+	 * cause a transaction rollback.
+	 * <p>See the description of {@link #rollbackForClassName} for further
+	 * information on how the specified names are treated.
+	 * <p>Similar to {@link org.springframework.transaction.interceptor.NoRollbackRuleAttribute#NoRollbackRuleAttribute(String exceptionName)}.
+	 * @see #noRollbackFor
+	 * @see org.springframework.transaction.interceptor.DefaultTransactionAttribute#rollbackOn(Throwable)
+	 */
+	String[] noRollbackForClassName() default {};
+
+}


### PR DESCRIPTION
This is a very simple change that exposes the `P` type in the parser which should make it easier to understand it in the documentation.

Currently Hackage and Stackage display the type of the first argument to `parser` in expanded form, i.e. `Parsec [L Token] () a` but for the parsers themselves it displays an unlinked `P`. This creates the illusion that these parsers do not satisfy the `parser` function, which they do.